### PR TITLE
avoid terminating the program from a goroutine

### DIFF
--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -154,6 +154,33 @@ func (a *awsClient) syncPerHostedZone(newAliasRecords []*route53.ResourceRecordS
 	return nil
 }
 
+func (a *awsClient) Consume(endpoints chan *pkg.Endpoint, errors chan error, done chan struct{}, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	log.Infoln("[AWS] Listening for events...")
+
+	for {
+		select {
+		case e, ok := <-endpoints:
+			if !ok {
+				log.Info("[AWS] channel closed")
+				return
+			}
+
+			log.Infof("[AWS] Processing (%s, %s, %s)\n", e.DNSName, e.IP, e.Hostname)
+
+			err := a.Process(e)
+			if err != nil {
+				errors <- err
+			}
+		case <-done:
+			log.Info("[AWS] Exited consuming loop.")
+			return
+		}
+	}
+}
+
 func (a *awsClient) Process(endpoint *pkg.Endpoint) error {
 	hostedZonesMap, err := a.client.GetHostedZones()
 	if err != nil {

--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -154,7 +154,7 @@ func (a *awsClient) syncPerHostedZone(newAliasRecords []*route53.ResourceRecordS
 	return nil
 }
 
-func (a *awsClient) Consume(endpoints chan *pkg.Endpoint, errors chan error, done chan struct{}, wg *sync.WaitGroup) {
+func (a *awsClient) Consume(endpoints <-chan *pkg.Endpoint, errors chan<- error, done <-chan struct{}, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 

--- a/consumers/consumers.go
+++ b/consumers/consumers.go
@@ -20,7 +20,7 @@ var params struct {
 
 type Consumer interface {
 	Sync([]*pkg.Endpoint) error
-	Consume(chan *pkg.Endpoint, chan error, chan struct{}, *sync.WaitGroup)
+	Consume(<-chan *pkg.Endpoint, chan<- error, <-chan struct{}, *sync.WaitGroup)
 	Process(*pkg.Endpoint) error
 }
 

--- a/consumers/consumers.go
+++ b/consumers/consumers.go
@@ -2,6 +2,7 @@ package consumers
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/zalando-incubator/mate/pkg"
 )
@@ -19,6 +20,7 @@ var params struct {
 
 type Consumer interface {
 	Sync([]*pkg.Endpoint) error
+	Consume(chan *pkg.Endpoint, chan error, chan struct{}, *sync.WaitGroup)
 	Process(*pkg.Endpoint) error
 }
 

--- a/consumers/google.go
+++ b/consumers/google.go
@@ -129,7 +129,7 @@ func (d *googleDNSConsumer) Sync(endpoints []*pkg.Endpoint) error {
 	return nil
 }
 
-func (d *googleDNSConsumer) Consume(endpoints chan *pkg.Endpoint, errors chan error, done chan struct{}, wg *sync.WaitGroup) {
+func (d *googleDNSConsumer) Consume(endpoints <-chan *pkg.Endpoint, errors chan<- error, done <-chan struct{}, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 

--- a/consumers/google.go
+++ b/consumers/google.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/zalando-incubator/mate/pkg"
 
@@ -126,6 +127,33 @@ func (d *googleDNSConsumer) Sync(endpoints []*pkg.Endpoint) error {
 	}
 
 	return nil
+}
+
+func (d *googleDNSConsumer) Consume(endpoints chan *pkg.Endpoint, errors chan error, done chan struct{}, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	log.Infoln("[Google] Listening for events...")
+
+	for {
+		select {
+		case e, ok := <-endpoints:
+			if !ok {
+				log.Info("[Google] channel closed")
+				return
+			}
+
+			log.Infof("[Google] Processing (%s, %s, %s)\n", e.DNSName, e.IP, e.Hostname)
+
+			err := d.Process(e)
+			if err != nil {
+				errors <- err
+			}
+		case <-done:
+			log.Info("[Google] Exited consuming loop.")
+			return
+		}
+	}
 }
 
 func (d *googleDNSConsumer) Process(endpoint *pkg.Endpoint) error {

--- a/consumers/stdout.go
+++ b/consumers/stdout.go
@@ -29,7 +29,7 @@ func (d *stdoutConsumer) Sync(endpoints []*pkg.Endpoint) error {
 	return nil
 }
 
-func (d *stdoutConsumer) Consume(endpoints chan *pkg.Endpoint, errors chan error, done chan struct{}, wg *sync.WaitGroup) {
+func (d *stdoutConsumer) Consume(endpoints <-chan *pkg.Endpoint, errors chan<- error, done <-chan struct{}, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer wg.Done()
 

--- a/consumers/stdout.go
+++ b/consumers/stdout.go
@@ -2,6 +2,9 @@ package consumers
 
 import (
 	"fmt"
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
 
 	"github.com/zalando-incubator/mate/pkg"
 )
@@ -24,6 +27,33 @@ func (d *stdoutConsumer) Sync(endpoints []*pkg.Endpoint) error {
 	}
 
 	return nil
+}
+
+func (d *stdoutConsumer) Consume(endpoints chan *pkg.Endpoint, errors chan error, done chan struct{}, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	log.Infoln("[Stdout] Listening for events...")
+
+	for {
+		select {
+		case e, ok := <-endpoints:
+			if !ok {
+				log.Info("[Stdout] channel closed")
+				return
+			}
+
+			log.Infof("[Stdout] Processing (%s, %s, %s)\n", e.DNSName, e.IP, e.Hostname)
+
+			err := d.Process(e)
+			if err != nil {
+				errors <- err
+			}
+		case <-done:
+			log.Info("[Stdout] Exited consuming loop.")
+			return
+		}
+	}
 }
 
 func (d *stdoutConsumer) Process(endpoint *pkg.Endpoint) error {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -24,10 +24,17 @@ type Controller struct {
 	consumer consumers.Consumer
 	options  *Options
 
+	// results is used to pass endpoints from producer to consumer
 	results chan *pkg.Endpoint
-	errors  chan error
-	done    chan struct{}
-	wg      sync.WaitGroup
+
+	// errors can be used by producers and consumers to report errors up
+	errors chan error
+
+	// done is used to send termination signals to nested goroutines
+	done chan struct{}
+
+	// wg keeps track of running goroutines
+	wg sync.WaitGroup
 }
 
 type Options struct {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -32,6 +32,7 @@ type Controller struct {
 
 type Options struct {
 	syncPeriod time.Duration
+	SyncOnly   bool
 }
 
 func New(producer producers.Producer, consumer consumers.Consumer, options *Options) *Controller {
@@ -56,7 +57,10 @@ func New(producer producers.Producer, consumer consumers.Consumer, options *Opti
 
 func (c *Controller) Run() chan error {
 	go c.Synchronize()
-	go c.Watch()
+
+	if !c.options.SyncOnly {
+		go c.Watch()
+	}
 
 	return c.errors
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ var params struct {
 	producer string
 	consumer string
 	debug    bool
+	syncOnly bool
 }
 
 var version = "Unknown"
@@ -21,6 +22,7 @@ func init() {
 	kingpin.Flag("producer", "The endpoints producer to use.").Required().StringVar(&params.producer)
 	kingpin.Flag("consumer", "The endpoints consumer to use.").Required().StringVar(&params.consumer)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&params.debug)
+	kingpin.Flag("sync-only", "Disable event watcher").BoolVar(&params.syncOnly)
 }
 
 func main() {
@@ -41,7 +43,10 @@ func main() {
 		log.Fatalf("Error creating consumer: %v", err)
 	}
 
-	ctrl := controller.New(p, c, nil)
+	opts := &controller.Options{
+		SyncOnly: params.syncOnly,
+	}
+	ctrl := controller.New(p, c, opts)
 	errors := ctrl.Run()
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ var params struct {
 	producer string
 	consumer string
 	debug    bool
-	syncOnly bool
 }
 
 var version = "Unknown"
@@ -22,7 +21,6 @@ func init() {
 	kingpin.Flag("producer", "The endpoints producer to use.").Required().StringVar(&params.producer)
 	kingpin.Flag("consumer", "The endpoints consumer to use.").Required().StringVar(&params.consumer)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&params.debug)
-	kingpin.Flag("sync-only", "Disable event watcher").BoolVar(&params.syncOnly)
 }
 
 func main() {
@@ -44,18 +42,5 @@ func main() {
 	}
 
 	ctrl := controller.New(p, c, nil)
-
-	err = ctrl.Synchronize()
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	if !params.syncOnly {
-		err = ctrl.Watch()
-		if err != nil {
-			log.Fatalln(err)
-		}
-	}
-
-	ctrl.Wait()
+	ctrl.RunAndWait()
 }

--- a/main.go
+++ b/main.go
@@ -42,5 +42,13 @@ func main() {
 	}
 
 	ctrl := controller.New(p, c, nil)
-	ctrl.RunAndWait()
+	errors := ctrl.Run()
+
+	go func() {
+		for {
+			log.Error(<-errors)
+		}
+	}()
+
+	ctrl.Wait()
 }

--- a/producers/kubernetes/ingress.go
+++ b/producers/kubernetes/ingress.go
@@ -55,11 +55,7 @@ func (a *kubernetesIngressProducer) Endpoints() ([]*pkg.Endpoint, error) {
 			continue
 		}
 
-		eps, err := a.convertIngressToEndpoint(ing)
-		if err != nil {
-			log.Error(err)
-			continue
-		}
+		eps := a.convertIngressToEndpoint(ing)
 
 		endpoints = append(endpoints, eps...)
 	}
@@ -116,12 +112,7 @@ loop:
 					continue
 				}
 
-				eps, err := a.convertIngressToEndpoint(*ing)
-				if err != nil {
-					// TODO: consider letting the service continue running and just log this error
-					errChan <- err
-					continue
-				}
+				eps := a.convertIngressToEndpoint(*ing)
 
 				for _, ep := range eps {
 					results <- ep
@@ -152,7 +143,7 @@ func validateIngress(ing extensions.Ingress) error {
 	return nil
 }
 
-func (a *kubernetesIngressProducer) convertIngressToEndpoint(ing extensions.Ingress) ([]*pkg.Endpoint, error) {
+func (a *kubernetesIngressProducer) convertIngressToEndpoint(ing extensions.Ingress) []*pkg.Endpoint {
 	endpoints := make([]*pkg.Endpoint, 0, len(ing.Spec.Rules))
 
 	for _, rule := range ing.Spec.Rules {
@@ -172,5 +163,5 @@ func (a *kubernetesIngressProducer) convertIngressToEndpoint(ing extensions.Ingr
 		endpoints = append(endpoints, ep)
 	}
 
-	return endpoints, nil
+	return endpoints
 }

--- a/producers/kubernetes/ingress.go
+++ b/producers/kubernetes/ingress.go
@@ -134,10 +134,9 @@ func validateIngress(ing extensions.Ingress) error {
 		)
 	case len(ing.Status.LoadBalancer.Ingress) > 1:
 		// TODO(linki): in case we have multiple ingress we can just create multiple A or CNAME records
-		return fmt.Errorf(
-			"[Ingress] Cannot register ingress '%s/%s'. More than one ingress is not supported",
-			ing.Namespace, ing.Name,
-		)
+		log.Warnf("[Ingress] Ingress '%s/%s' has more than one ingress (%d). Only using the first one.",
+			ing.Namespace, ing.Name, len(ing.Status.LoadBalancer.Ingress))
+		return nil
 	}
 
 	return nil

--- a/producers/kubernetes/ingress.go
+++ b/producers/kubernetes/ingress.go
@@ -20,21 +20,19 @@ import (
 type kubernetesIngressProducer struct {
 	client *k8s.Clientset
 	tmpl   *template.Template
-
-	wg sync.WaitGroup
 }
 
 func NewKubernetesIngress() (*kubernetesIngressProducer, error) {
 	client, err := kubernetes.NewClient(params.kubeServer)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to setup Kubernetes API client: %v", err)
+		return nil, fmt.Errorf("[Ingress] Unable to setup Kubernetes API client: %v", err)
 	}
 
 	tmpl, err := template.New("endpoint").Funcs(template.FuncMap{
 		"trimPrefix": strings.TrimPrefix,
 	}).Parse(params.format)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing template: %s", err)
+		return nil, fmt.Errorf("[Ingress] Error parsing template: %s", err)
 	}
 
 	return &kubernetesIngressProducer{
@@ -46,7 +44,7 @@ func NewKubernetesIngress() (*kubernetesIngressProducer, error) {
 func (a *kubernetesIngressProducer) Endpoints() ([]*pkg.Endpoint, error) {
 	allIngress, err := a.client.Ingresses(api.NamespaceAll).List(api.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Unable to retrieve list of ingress: %v", err)
+		return nil, fmt.Errorf("[Ingress] Unable to retrieve list of ingress: %v", err)
 	}
 
 	endpoints := make([]*pkg.Endpoint, 0)
@@ -69,76 +67,78 @@ func (a *kubernetesIngressProducer) Endpoints() ([]*pkg.Endpoint, error) {
 	return endpoints, nil
 }
 
-func (a *kubernetesIngressProducer) Monitor() (chan *pkg.Endpoint, chan error) {
-	channel := make(chan *pkg.Endpoint)
-	errors := make(chan error)
+func (a *kubernetesIngressProducer) Monitor(results chan *pkg.Endpoint, errChan chan error, done chan struct{}, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
 
-	a.wg.Add(1)
-
-	go func() {
-		defer a.wg.Done()
-
-		for {
-			w, err := a.client.Ingresses(api.NamespaceAll).Watch(api.ListOptions{})
-			if err != nil {
-				errors <- fmt.Errorf("Unable to watch list of ingress: %v", err)
+	for {
+		w, err := a.client.Ingresses(api.NamespaceAll).Watch(api.ListOptions{})
+		if err != nil {
+			errChan <- fmt.Errorf("[Ingress] Unable to watch list of ingress: %v", err)
+			select {
+			case <-done:
+				log.Info("[Ingress] Exited monitoring loop.")
+				return
+			default:
 				time.Sleep(5 * time.Second)
 				continue
 			}
-
-			for event := range w.ResultChan() {
-				if event.Type == watch.Error {
-					// TODO: consider allowing the service continue running and just log this error
-					errors <- fmt.Errorf("Event listener received an error, terminating: %v", event)
-					continue
-				}
-
-				if event.Type != watch.Added && event.Type != watch.Modified {
-					continue
-				}
-
-				ing, ok := event.Object.(*extensions.Ingress)
-				if !ok {
-					// If the object wasn't a Service we can safely ignore it
-					log.Printf("Cannot cast object to ingress: %v", ing)
-					continue
-				}
-
-				log.Printf("%s: %s/%s", event.Type, ing.Namespace, ing.Name)
-
-				if err := validateIngress(*ing); err != nil {
-					log.Warnln(err)
-					continue
-				}
-
-				eps, err := a.convertIngressToEndpoint(*ing)
-				if err != nil {
-					// TODO: consider letting the service continue running and just log this error
-					errors <- err
-					continue
-				}
-
-				for _, ep := range eps {
-					channel <- ep
-				}
-			}
 		}
-	}()
 
-	return channel, errors
+		select {
+		case event := <-w.ResultChan():
+			if event.Type == watch.Error {
+				// TODO: consider allowing the service continue running and just log this error
+				errChan <- fmt.Errorf("[Ingress] Event listener received an error, terminating: %v", event)
+				continue
+			}
+
+			if event.Type != watch.Added && event.Type != watch.Modified {
+				continue
+			}
+
+			ing, ok := event.Object.(*extensions.Ingress)
+			if !ok {
+				// If the object wasn't a Service we can safely ignore it
+				log.Printf("[Ingress] Cannot cast object to ingress: %v", ing)
+				continue
+			}
+
+			log.Printf("%s: %s/%s", event.Type, ing.Namespace, ing.Name)
+
+			if err := validateIngress(*ing); err != nil {
+				log.Warnln(err)
+				continue
+			}
+
+			eps, err := a.convertIngressToEndpoint(*ing)
+			if err != nil {
+				// TODO: consider letting the service continue running and just log this error
+				errChan <- err
+				continue
+			}
+
+			for _, ep := range eps {
+				results <- ep
+			}
+		case <-done:
+			log.Info("[Ingress] Exited monitoring loop.")
+			return
+		}
+	}
 }
 
 func validateIngress(ing extensions.Ingress) error {
 	switch {
 	case len(ing.Status.LoadBalancer.Ingress) == 0:
 		return fmt.Errorf(
-			"The load balancer of ingress '%s/%s' does not have any ingress.",
+			"[Ingress] The load balancer of ingress '%s/%s' does not have any ingress.",
 			ing.Namespace, ing.Name,
 		)
 	case len(ing.Status.LoadBalancer.Ingress) > 1:
 		// TODO(linki): in case we have multiple ingress we can just create multiple A or CNAME records
 		return fmt.Errorf(
-			"Cannot register ingress '%s/%s'. More than one ingress is not supported",
+			"[Ingress] Cannot register ingress '%s/%s'. More than one ingress is not supported",
 			ing.Namespace, ing.Name,
 		)
 	}

--- a/producers/kubernetes/service.go
+++ b/producers/kubernetes/service.go
@@ -119,7 +119,7 @@ loop:
 
 				ep, err := a.convertServiceToEndpoint(*svc)
 				if err != nil {
-					errChan <- err
+					log.Warnln(err)
 					continue
 				}
 

--- a/producers/kubernetes/service.go
+++ b/producers/kubernetes/service.go
@@ -141,10 +141,9 @@ func validateService(svc api.Service) error {
 		)
 	case len(svc.Status.LoadBalancer.Ingress) > 1:
 		// TODO(linki): in case we have multiple ingress we can just create multiple A or CNAME records
-		return fmt.Errorf(
-			"[Service] Cannot register service '%s/%s'. More than one ingress is not supported",
-			svc.Namespace, svc.Name,
-		)
+		log.Warnf("[Service] Service '%s/%s' has more than one ingress (%d). Only using the first one.",
+			svc.Namespace, svc.Name, len(svc.Status.LoadBalancer.Ingress))
+		return nil
 	}
 
 	return nil

--- a/producers/producers.go
+++ b/producers/producers.go
@@ -2,6 +2,7 @@ package producers
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/zalando-incubator/mate/pkg"
 	"github.com/zalando-incubator/mate/producers/fake"
@@ -10,7 +11,7 @@ import (
 
 type Producer interface {
 	Endpoints() ([]*pkg.Endpoint, error)
-	Monitor() (chan *pkg.Endpoint, chan error)
+	Monitor(chan *pkg.Endpoint, chan error, chan struct{}, *sync.WaitGroup)
 }
 
 func New(name string) (Producer, error) {

--- a/producers/producers.go
+++ b/producers/producers.go
@@ -10,8 +10,7 @@ import (
 
 type Producer interface {
 	Endpoints() ([]*pkg.Endpoint, error)
-	StartWatch() error
-	ResultChan() (chan *pkg.Endpoint, error)
+	Monitor() (chan *pkg.Endpoint, chan error)
 }
 
 func New(name string) (Producer, error) {


### PR DESCRIPTION
looking for feedback

partly addresses propagating errors up.

to go further i think we have to change the blocking `StartWatch`/`ResultChan` interface to something else.