### PR TITLE
proposal: self-deploying mate

### DIFF
--- a/deploy/manifest.go
+++ b/deploy/manifest.go
@@ -1,0 +1,107 @@
+package deploy
+
+import (
+	"fmt"
+	"net/url"
+
+	"k8s.io/client-go/pkg/api/resource"
+	"k8s.io/client-go/pkg/api/unversioned"
+	api "k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+
+	"github.com/zalando-incubator/mate/pkg/kubernetes"
+)
+
+type manifest struct {
+	version string
+	args    []string
+}
+
+func NewManifest(version string, args []string) *manifest {
+	for i, val := range args {
+		if val == "--deploy" {
+			args = append(args[:i], args[i+1:]...)
+		}
+	}
+
+	return &manifest{
+		version: version,
+		args:    args,
+	}
+}
+
+func (m *manifest) Deploy() error {
+	var manifest = &extensions.Deployment{
+		TypeMeta: unversioned.TypeMeta{
+			APIVersion: "extensions/v1beta1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: api.ObjectMeta{
+			Name:      "mate",
+			Namespace: "default",
+			Labels: map[string]string{
+				"application": "mate",
+				"version":     m.version,
+			},
+		},
+		Spec: extensions.DeploymentSpec{
+			Selector: &unversioned.LabelSelector{
+				MatchLabels: map[string]string{
+					"application": "mate",
+				},
+			},
+			Template: api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"application": "mate",
+						"version":     m.version,
+					},
+					Annotations: map[string]string{
+						"scheduler.alpha.kubernetes.io/critical-pod": "",
+						"scheduler.alpha.kubernetes.io/tolerations":  `[{"key":"CriticalAddonsOnly", "operator":"Exists"}]`,
+						"iam.amazonaws.com/role":                     "kube-aws-test-linki39-app-mate",
+					},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  "mate",
+							Image: "registry.opensource.zalan.do/teapot/mate:" + m.version,
+							Args:  m.args,
+							Env: []api.EnvVar{
+								{
+									Name:  "AWS_REGION",
+									Value: "eu-central-1",
+								},
+							},
+							Resources: api.ResourceRequirements{
+								Requests: api.ResourceList{
+									"cpu":    resource.MustParse("50m"),
+									"memory": resource.MustParse("25Mi"),
+								},
+								Limits: api.ResourceList{
+									"cpu":    resource.MustParse("200m"),
+									"memory": resource.MustParse("200Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	url, _ := url.Parse("http://127.0.0.1:8001")
+
+	client, err := kubernetes.NewClient(url)
+	if err != nil {
+		return fmt.Errorf("Unable to setup Kubernetes API client: %v", err)
+	}
+
+	_, err = client.Extensions().Deployments(api.NamespaceDefault).Update(manifest)
+	if err != nil {
+		return fmt.Errorf("Unable to submit manifest: %v", err)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/zalando-incubator/mate/consumers"
 	"github.com/zalando-incubator/mate/controller"
+	"github.com/zalando-incubator/mate/deploy"
 	"github.com/zalando-incubator/mate/producers"
 )
 
@@ -14,6 +17,7 @@ var params struct {
 	consumer string
 	debug    bool
 	syncOnly bool
+	deploy   bool
 }
 
 var version = "Unknown"
@@ -23,6 +27,7 @@ func init() {
 	kingpin.Flag("consumer", "The endpoints consumer to use.").Required().StringVar(&params.consumer)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&params.debug)
 	kingpin.Flag("sync-only", "Disable event watcher").BoolVar(&params.syncOnly)
+	kingpin.Flag("deploy", "When set this deploys mate in the targt cluster.").BoolVar(&params.deploy)
 }
 
 func main() {
@@ -31,6 +36,15 @@ func main() {
 
 	if params.debug {
 		log.SetLevel(log.DebugLevel)
+	}
+
+	if params.deploy {
+		err := deploy.NewManifest(version, os.Args[1:]).Deploy()
+		if err != nil {
+			log.Fatalf("Error deploying manifest: %v", err)
+		}
+
+		os.Exit(0)
 	}
 
 	p, err := producers.New(params.producer)


### PR DESCRIPTION
Proof-of-concept of `mate` deploying itself into a cluster.

Why? Instead of manually fiddling with `kubectl` and manifest files in our cloud config wouldn't it be nice if `mate` can take care of it, including some sanitization?

demo:

```bash
# make sure mate can connect to a cluster (let's use kubectl proxy for now)
$ kubectl proxy &

# get mate
$ go get github.com/zalando-incubator/mate

# deploy mate in the target cluster
$ mate --producer fake --consumer stdout --deploy

# check that it's running
$ kubectl get pods
NAME                              READY     STATUS              RESTARTS   AGE
mate-3919908877-2lhq5             1/1       ContainerCreating   0          1m

# check that the params were taken over
$ kubectl get deployment mate -o json | jq '.spec.template.spec.containers[0].args'
[
  "--producer",
  "fake",
  "--consumer",
  "stdout"
]
```

### Benefit

Keep program logic and knowledge about how it's going to be deployed together. No need to split these parts into separate things.

By making the application aware of its deployment platform it can make application-aware deployment decisions, e.g. correct number of replicas, required third-party resources, where to find the service account credentials, ...

Regarding our cluster: Instead of putting yaml files and Kubernetes API calls in our cloud config we would just one-shot call `mate` with the `deploy` flag passing the correct configuration and it would self-deploy into the cluster. It could potentially get some configuration from the environment, e.g. the cluster name.

Idea based on talks by Brendan Burns and Kelsey Hightower.
- https://www.youtube.com/watch?v=VQ7kpxPXTm4
- https://github.com/kelseyhightower/hello-universe

A similar approach is used by https://github.com/skippbox/kubeless#usage.

Does it make sense to you? Feedback welcome.