### PR TITLE
Update Resource Records only when necessary

### DIFF
--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -83,7 +83,7 @@ func (a *awsClient) Sync(endpoints []*pkg.Endpoint) error {
 		}
 
 		// make sure record only updated when target changes, not to spam AWS route53 API with dummy updates
-		if existingRecordInfo.Target != aws.StringValue(newAliasRecord.AliasTarget.DNSName) {
+		if pkg.SanitizeDNSName(existingRecordInfo.Target) != aws.StringValue(newAliasRecord.AliasTarget.DNSName) {
 			newTXTRecord := a.client.GetAssignedTXTRecordObject(newAliasRecord)
 			upsert = append(upsert, newAliasRecord, newTXTRecord)
 		}

--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -19,9 +19,10 @@ import (
 type AWSClient interface {
 	ListRecordSets() ([]*route53.ResourceRecordSet, error)
 	ChangeRecordSets(upsert, del, create []*route53.ResourceRecordSet) error
-	MapEndpoints(endpoints []*pkg.Endpoint) ([]*route53.ResourceRecordSet, error)
+	EndpointsToAlias(endpoints []*pkg.Endpoint) ([]*route53.ResourceRecordSet, error)
 	RecordInfo(records []*route53.ResourceRecordSet) map[string]*pkg.RecordInfo
 	GetGroupID() string
+	GetAssignedTXTRecordObject(record *route53.ResourceRecordSet) *route53.ResourceRecordSet
 }
 
 type awsClient struct {
@@ -33,7 +34,7 @@ func init() {
 	kingpin.Flag("aws-record-group-id", "Identifier to filter the mate records ").StringVar(&params.awsGroupID)
 }
 
-// NewAWS reates a Consumer instance to sync and process DNS
+// NewAWSRoute53 reates a Consumer instance to sync and process DNS
 // entries in AWS Route53.
 func NewAWSRoute53() (Consumer, error) {
 	if params.awsHostedZone == "" {
@@ -53,45 +54,46 @@ func withClient(c AWSClient) *awsClient {
 }
 
 func (a *awsClient) Sync(endpoints []*pkg.Endpoint) error {
-	records, err := a.client.ListRecordSets()
+	existingRecords, err := a.client.ListRecordSets()
 	if err != nil {
 		return err
 	}
 
-	recordMap := a.client.RecordInfo(records)
-
-	next, err := a.client.MapEndpoints(endpoints)
+	recordInfoMap := a.client.RecordInfo(existingRecords)
+	newAliasRecords, err := a.client.EndpointsToAlias(endpoints)
 	if err != nil {
 		return err
 	}
 
 	var upsert, del []*route53.ResourceRecordSet
 
-	for _, endpoint := range next {
-		recordInfo, exist := recordMap[aws.StringValue(endpoint.Name)]
+	for _, newAliasRecord := range newAliasRecords {
+		existingRecordInfo, exist := recordInfoMap[aws.StringValue(newAliasRecord.Name)]
 
-		if !exist { //record does not exist, create it
-			upsert = append(upsert, endpoint)
+		if !exist { //record does not exist, create with
+			newTXTRecord := a.client.GetAssignedTXTRecordObject(newAliasRecord)
+			upsert = append(upsert, newAliasRecord, newTXTRecord)
 			continue
 		}
 
-		if recordInfo.GroupID != a.client.GetGroupID() { // there exist a record with a different or empty group ID
-			log.Warnf("Skipping record %s: with a group ID: %s", aws.StringValue(endpoint.Name), recordInfo.GroupID)
+		if existingRecordInfo.GroupID != a.client.GetGroupID() { // there exist a record with a different or empty group ID
+			log.Warnf("Skipping record %s: with a group ID: %s", aws.StringValue(newAliasRecord.Name), existingRecordInfo.GroupID)
 			continue
 		}
 
-		//make sure record only updated when target changes, not to spam AWS route53 api with dummy updates
-		if recordInfo.Target != aws.StringValue(endpoint.AliasTarget.DNSName) {
-			upsert = append(upsert, endpoint)
+		// make sure record only updated when target changes, not to spam AWS route53 API with dummy updates
+		if existingRecordInfo.Target != aws.StringValue(newAliasRecord.AliasTarget.DNSName) {
+			newTXTRecord := a.client.GetAssignedTXTRecordObject(newAliasRecord)
+			upsert = append(upsert, newAliasRecord, newTXTRecord)
 		}
 	}
 
-	for _, record := range records {
-		recordInfo := recordMap[aws.StringValue(record.Name)]
+	for _, record := range existingRecords {
+		recordInfo := recordInfoMap[aws.StringValue(record.Name)]
 		if recordInfo.GroupID == a.client.GetGroupID() {
 			remove := true
-			for _, endpoint := range next {
-				if aws.StringValue(endpoint.Name) == aws.StringValue(record.Name) {
+			for _, newAliasRecord := range newAliasRecords {
+				if aws.StringValue(newAliasRecord.Name) == aws.StringValue(record.Name) {
 					remove = false
 				}
 			}
@@ -111,11 +113,12 @@ func (a *awsClient) Sync(endpoints []*pkg.Endpoint) error {
 }
 
 func (a *awsClient) Process(endpoint *pkg.Endpoint) error {
-	create, err := a.client.MapEndpoints([]*pkg.Endpoint{endpoint})
+	alias, err := a.client.EndpointsToAlias([]*pkg.Endpoint{endpoint})
 	if err != nil {
 		return err
 	}
-
+	txt := a.client.GetAssignedTXTRecordObject(alias[0])
+	create := []*route53.ResourceRecordSet{alias[0], txt}
 	err = a.client.ChangeRecordSets(nil, nil, create)
 	if err != nil && strings.Contains(err.Error(), "it already exists") {
 		log.Warnf("Record [name=%s] could not be created, another record with same name already exists", endpoint.DNSName)

--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -70,14 +70,19 @@ func (a *awsClient) Sync(endpoints []*pkg.Endpoint) error {
 	for _, endpoint := range next {
 		groupID, exist := recordMap[aws.StringValue(endpoint.Name)]
 
-		if exist && groupID != a.client.GetGroupID() {
+		if !exist { //record does not exist, create it
+			upsert = append(upsert, endpoint)
+			continue
+		}
+
+		if groupID != a.client.GetGroupID() { // there exist a record with a different or empty group ID
 			log.Warnf("Skipping record %s: with a group ID: %s", aws.StringValue(endpoint.Name), groupID)
 			continue
 		}
 
-		if !exist || (exist && groupID == a.client.GetGroupID()) {
-			upsert = append(upsert, endpoint)
-		}
+		//make sure record really requires update, not to spam AWS route53 api with dummy updates
+		if 
+		2
 	}
 
 	for _, record := range records {

--- a/consumers/aws_test.go
+++ b/consumers/aws_test.go
@@ -47,7 +47,8 @@ func checkEndpointSlices(got []*route53.ResourceRecordSet, expect []*route53.Res
 		var found bool
 		for _, eep := range expect {
 			if *ep.Type == "A" {
-				if *eep.Type == "A" && *eep.AliasTarget.DNSName == *ep.AliasTarget.DNSName && *ep.Name == *eep.Name {
+				if *eep.Type == "A" && pkg.SanitizeDNSName(*eep.AliasTarget.DNSName) == pkg.SanitizeDNSName(*ep.AliasTarget.DNSName) &&
+					*ep.Name == *eep.Name {
 					found = true
 				}
 				continue

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -113,8 +113,8 @@ func (c *Client) MapEndpoints(endpoints []*pkg.Endpoint) ([]*route53.ResourceRec
 	var rset []*route53.ResourceRecordSet
 
 	for _, ep := range endpoints {
-		if LoadBalancerZoneID, exist := zoneIDs[ep.Hostname]; exist {
-			rset = append(rset, c.MapEndpointAlias(ep, aws.String(LoadBalancerZoneID)))
+		if loadBalancerZoneID, exist := zoneIDs[ep.Hostname]; exist {
+			rset = append(rset, c.MapEndpointAlias(ep, aws.String(loadBalancerZoneID)))
 			rset = append(rset, c.MapEndpointTXT(ep))
 		} else {
 			log.Errorf("Canonical Zone ID for endpoint: %s is not found", ep.Hostname)

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	EvaluateTargetHealth = true
+	evaluateTargetHealth = true
 	defaultTxtTTL        = int64(300)
 )
 
@@ -27,27 +27,27 @@ func (c *Client) initRoute53Client() (*route53.Route53, error) {
 	return route53.New(session), nil
 }
 
-//MapEndpointAlias ...
-//create an AWS A Alias record
-func (c *Client) MapEndpointAlias(ep *pkg.Endpoint, aliasHostedZoneID *string) *route53.ResourceRecordSet {
+//endpointToAlias ...
+//convert endpoint to an AWS A Alias record
+func (c *Client) EndpointToAlias(ep *pkg.Endpoint, aliasHostedZoneID *string) *route53.ResourceRecordSet {
 	rs := &route53.ResourceRecordSet{
 		Type: aws.String("A"),
 		Name: aws.String(pkg.SanitizeDNSName(ep.DNSName)),
 		AliasTarget: &route53.AliasTarget{
 			DNSName:              aws.String(ep.Hostname),
-			EvaluateTargetHealth: aws.Bool(EvaluateTargetHealth),
+			EvaluateTargetHealth: aws.Bool(evaluateTargetHealth),
 			HostedZoneId:         aliasHostedZoneID,
 		},
 	}
 	return rs
 }
 
-//MapEndpointTXT ...
-//create an AWS TXT record
-func (c *Client) MapEndpointTXT(ep *pkg.Endpoint) *route53.ResourceRecordSet {
+//getTXTRecord ...
+//gets AWS TXT Record Resource object for a given DNS entry
+func (c *Client) createTXTRecordObject(DNSName string) *route53.ResourceRecordSet {
 	rs := &route53.ResourceRecordSet{
 		Type: aws.String("TXT"),
-		Name: aws.String(pkg.SanitizeDNSName(ep.DNSName)),
+		Name: aws.String(pkg.SanitizeDNSName(DNSName)),
 		TTL:  aws.Int64(defaultTxtTTL),
 		ResourceRecords: []*route53.ResourceRecord{{
 			Value: aws.String(c.GetGroupID()),

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -34,7 +34,7 @@ func (c *Client) endpointToAlias(ep *pkg.Endpoint, canonicalZoneID *string) *rou
 		Type: aws.String("A"),
 		Name: aws.String(pkg.SanitizeDNSName(ep.DNSName)),
 		AliasTarget: &route53.AliasTarget{
-			DNSName:              aws.String(ep.Hostname),
+			DNSName:              aws.String(pkg.SanitizeDNSName(ep.Hostname)),
 			EvaluateTargetHealth: aws.Bool(evaluateTargetHealth),
 			HostedZoneId:         canonicalZoneID,
 		},

--- a/pkg/aws/route53.go
+++ b/pkg/aws/route53.go
@@ -29,14 +29,14 @@ func (c *Client) initRoute53Client() (*route53.Route53, error) {
 
 //endpointToAlias ...
 //convert endpoint to an AWS A Alias record
-func (c *Client) endpointToAlias(ep *pkg.Endpoint, aliasHostedZoneID *string) *route53.ResourceRecordSet {
+func (c *Client) endpointToAlias(ep *pkg.Endpoint, canonicalZoneID *string) *route53.ResourceRecordSet {
 	rs := &route53.ResourceRecordSet{
 		Type: aws.String("A"),
 		Name: aws.String(pkg.SanitizeDNSName(ep.DNSName)),
 		AliasTarget: &route53.AliasTarget{
 			DNSName:              aws.String(ep.Hostname),
 			EvaluateTargetHealth: aws.Bool(evaluateTargetHealth),
-			HostedZoneId:         aliasHostedZoneID,
+			HostedZoneId:         canonicalZoneID,
 		},
 	}
 	return rs

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -18,7 +18,7 @@ func TestMapEndpointAlias(t *testing.T) {
 		IP:       "10.202.10.123",
 		Hostname: "amazon.elb.com",
 	}
-	rsA := client.MapEndpointAlias(ep, &zoneID)
+	rsA := client.EndpointToAlias(ep, &zoneID)
 	if *rsA.Type != "A" || *rsA.Name != pkg.SanitizeDNSName(ep.DNSName) ||
 		*rsA.AliasTarget.DNSName != ep.Hostname ||
 		*rsA.AliasTarget.HostedZoneId != zoneID {
@@ -34,7 +34,8 @@ func TestMapEndpointTXT(t *testing.T) {
 		IP:       "10.202.10.123",
 		Hostname: "amazon.elb.com",
 	}
-	rsTXT := client.MapEndpointTXT(ep)
+	rsA := client.EndpointToAlias(ep, &zoneID)
+	rsTXT := client.GetAssignedTXTRecordObject(rsA)
 	if *rsTXT.Type != "TXT" ||
 		*rsTXT.Name != "example.com." ||
 		len(rsTXT.ResourceRecords) != 1 ||

--- a/pkg/aws/route53_test.go
+++ b/pkg/aws/route53_test.go
@@ -22,7 +22,7 @@ func TestEndpointToAlias(t *testing.T) {
 	}
 	rsA := client.endpointToAlias(ep, &zoneID)
 	if *rsA.Type != "A" || *rsA.Name != pkg.SanitizeDNSName(ep.DNSName) ||
-		*rsA.AliasTarget.DNSName != ep.Hostname ||
+		*rsA.AliasTarget.DNSName != pkg.SanitizeDNSName(ep.Hostname) ||
 		*rsA.AliasTarget.HostedZoneId != zoneID {
 		t.Error("Should create an A record")
 	}

--- a/pkg/aws/test/test_client.go
+++ b/pkg/aws/test/test_client.go
@@ -31,21 +31,21 @@ func (c *Client) ListRecordSets() ([]*route53.ResourceRecordSet, error) {
 
 func (c *Client) EndpointsToAlias(endpoints []*pkg.Endpoint) ([]*route53.ResourceRecordSet, error) {
 	var rset []*route53.ResourceRecordSet
-	aliasZoneID := "test"
+	canonicalZoneID := "test"
 	for _, ep := range endpoints {
-		rset = append(rset, c.endpointToAlias(ep, &aliasZoneID))
+		rset = append(rset, c.endpointToAlias(ep, &canonicalZoneID))
 	}
 	return rset, nil
 }
 
-func (c *Client) endpointToAlias(ep *pkg.Endpoint, aliasHostedZoneID *string) *route53.ResourceRecordSet {
+func (c *Client) endpointToAlias(ep *pkg.Endpoint, canonicalZoneID *string) *route53.ResourceRecordSet {
 	rs := &route53.ResourceRecordSet{
 		Type: aws.String("A"),
 		Name: aws.String(pkg.SanitizeDNSName(ep.DNSName)),
 		AliasTarget: &route53.AliasTarget{
 			DNSName:              aws.String(ep.Hostname),
 			EvaluateTargetHealth: aws.Bool(false),
-			HostedZoneId:         aliasHostedZoneID,
+			HostedZoneId:         canonicalZoneID,
 		},
 	}
 	return rs

--- a/pkg/aws/test/test_client.go
+++ b/pkg/aws/test/test_client.go
@@ -28,12 +28,11 @@ func (c *Client) ListRecordSets() ([]*route53.ResourceRecordSet, error) {
 	return c.Current, nil
 }
 
-func (c *Client) MapEndpoints(endpoints []*pkg.Endpoint) ([]*route53.ResourceRecordSet, error) {
+func (c *Client) EndpointsToAlias(endpoints []*pkg.Endpoint) ([]*route53.ResourceRecordSet, error) {
 	var rset []*route53.ResourceRecordSet
 	aliasZoneID := "test"
 	for _, ep := range endpoints {
-		rset = append(rset, c.Client.MapEndpointAlias(ep, &aliasZoneID))
-		rset = append(rset, c.Client.MapEndpointTXT(ep))
+		rset = append(rset, c.Client.EndpointToAlias(ep, &aliasZoneID))
 	}
 	return rset, nil
 }

--- a/pkg/aws/test/test_client.go
+++ b/pkg/aws/test/test_client.go
@@ -43,7 +43,7 @@ func (c *Client) endpointToAlias(ep *pkg.Endpoint, canonicalZoneID *string) *rou
 		Type: aws.String("A"),
 		Name: aws.String(pkg.SanitizeDNSName(ep.DNSName)),
 		AliasTarget: &route53.AliasTarget{
-			DNSName:              aws.String(ep.Hostname),
+			DNSName:              aws.String(pkg.SanitizeDNSName(ep.Hostname)),
 			EvaluateTargetHealth: aws.Bool(false),
 			HostedZoneId:         canonicalZoneID,
 		},

--- a/pkg/recordinfo.go
+++ b/pkg/recordinfo.go
@@ -1,0 +1,8 @@
+package pkg
+
+//RecordInfo stores the information relevant to the record that were created
+//mainly used to identify if the Route53 records needs to be updated
+type RecordInfo struct {
+	Target  string
+	GroupID string
+}


### PR DESCRIPTION
Current implementation pushes changes to AWS Route53 on each sync cycle, even though most of the time there are no actual changes to Kubernetes ingress or services.  

PR is supposed to figure out if there are actually any changes to the Kubernetes resources and only then push them to the Consumer, **currently only AWS Route53**.

Description of the reason why this improvement is required: 
https://github.com/zalando-incubator/mate/issues/23 