### PR TITLE
Remove kubectl proxy from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,17 @@ Analogous to the AWS case with the difference that it doesn't use the AWS specif
 
 ### Kubernetes
 
-By default Mate will retrieve the list of services from the Kubernetes API server via `http://127.0.0.1:8001` (for local testing use `kubectl proxy`), however the API server url can be configured with the `kubernetes-server` flag.
-Mate will listen for events from the API Server and creates corresponding records for newly created services. Further synchronization (create, update and removal) will occur every minute. There's an initial syncronization when Mate boots up so it's safe to reboot the process at any point in time. If you only like to do the synchronization you can use the `sync-only` flag.
+Mate will listen for events from the API Server and create corresponding
+records for newly created services. Further synchronization (create, update and
+removal) will occur every minute. There's an initial syncronization when Mate
+boots up so it's safe to reboot the process at any point in time. If you only
+like to do the synchronization you can use the `sync-only` flag.
+
+By default Mate uses the in cluster environment to configure the connection to
+the API server. When running outside a cluster it is possible to configure the
+API server url using the flag `kubernetes-server`. For instance you can run
+Mate locally with the server URL set to `http://127.0.0.1:8001` and use
+`kubectl proxy` to forward requests to a cluster.
 
 # Producers and Consumers
 

--- a/mate.yml
+++ b/mate.yml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: mate
-        image: registry.opensource.zalan.do/teapot/mate:v0.0.7
+        image: registry.opensource.zalan.do/teapot/mate:v0.2.0
         args:
         - --producer=kubernetes
         - --kubernetes-domain=example.org.
@@ -20,10 +20,3 @@ spec:
         - --google-project=my-project
         - --google-zone=example-org
         - --google-record-group-id=my-cluster
-      - name: kubectl
-        image: quay.io/coreos/hyperkube:v1.4.5_coreos.0
-        command:
-        - /hyperkube
-        args:
-        - kubectl
-        - proxy


### PR DESCRIPTION
Removes unneeded kubectl proxy container from example manifest, and
describes the automatic in-cluster configuration that was added in
a282b22.