### PR TITLE
Changed to replace latest and not upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/alpine:UPSTREAM
+FROM registry.opensource.zalan.do/stups/alpine:latest
 MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 
 # add scm-source

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ build/osx/$(BINARY): $(SOURCES)
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/osx/$(BINARY) -ldflags "$(LDFLAGS)" .
 
 $(DOCKERFILE).upstream: $(DOCKERFILE)
-	sed "s@UPSTREAM@$(shell $(shell head -1 $(DOCKERFILE) | sed -E 's@FROM (.*)/(.*)/(.*):.*@pierone latest \2 \3 --url \1@'))@" $(DOCKERFILE) > $(DOCKERFILE).upstream
+	sed "s@latest@$(shell $(shell head -1 $(DOCKERFILE) | sed -E 's@FROM (.*)/(.*)/(.*):.*@pierone latest \2 \3 --url \1@'))@" $(DOCKERFILE) > $(DOCKERFILE).upstream
 
 build.docker: $(DOCKERFILE).upstream scm-source.json build.linux
 	docker build --rm -t "$(IMAGE):$(TAG)" -f $(DOCKERFILE).upstream .


### PR DESCRIPTION
@linki @mikkeloscar @ideahitme This addresses issue #35. I wonder if there is actually not use `latest` directly, can you help with that. If not, we can address it in this PR. 