### PR TITLE
GCP: allow dns entries to point to multiple IPs

### DIFF
--- a/consumers/google.go
+++ b/consumers/google.go
@@ -21,6 +21,7 @@ const (
 
 type googleDNSConsumer struct {
 	client *dns.Service
+	labels []string
 }
 
 type ownedRecord struct {
@@ -63,8 +64,11 @@ func NewGoogleDNS() (Consumer, error) {
 		return nil, fmt.Errorf("Error creating DNS service: %v", err)
 	}
 
+	labels := []string{heritageLabel, labelPrefix + params.recordGroupID}
+
 	return &googleDNSConsumer{
 		client: client,
+		labels: labels,
 	}, nil
 }
 
@@ -104,7 +108,7 @@ func (d *googleDNSConsumer) Sync(endpoints []*pkg.Endpoint) error {
 			},
 			&dns.ResourceRecordSet{
 				Name:    dnsName,
-				Rrdatas: []string{heritageLabel, labelPrefix + params.recordGroupID},
+				Rrdatas: d.labels,
 				Ttl:     300,
 				Type:    "TXT",
 			},
@@ -122,7 +126,7 @@ func (d *googleDNSConsumer) Sync(endpoints []*pkg.Endpoint) error {
 				},
 				&dns.ResourceRecordSet{
 					Name:    r.record.Name,
-					Rrdatas: []string{heritageLabel, labelPrefix + params.recordGroupID},
+					Rrdatas: d.labels,
 					Ttl:     r.record.Ttl,
 					Type:    "TXT",
 				},
@@ -150,7 +154,7 @@ func (d *googleDNSConsumer) Process(endpoint *pkg.Endpoint) error {
 		},
 		&dns.ResourceRecordSet{
 			Name:    endpoint.DNSName,
-			Rrdatas: []string{heritageLabel, labelPrefix + params.recordGroupID},
+			Rrdatas: d.labels,
 			Ttl:     300,
 			Type:    "TXT",
 		},

--- a/consumers/google.go
+++ b/consumers/google.go
@@ -191,9 +191,9 @@ func (d *googleDNSConsumer) currentRecords() (map[string]*ownedRecord, error) {
 
 	for _, r := range resp.Rrsets {
 		if r.Type == "A" || r.Type == "TXT" {
-			record := records[r.Name]
+			record, exists := records[r.Name]
 
-			if record == nil {
+			if !exists {
 				record = &ownedRecord{}
 			}
 

--- a/consumers/google.go
+++ b/consumers/google.go
@@ -83,22 +83,17 @@ func (d *googleDNSConsumer) Sync(endpoints []*pkg.Endpoint) error {
 
 	change := new(dns.Change)
 
-	records := make(map[string][]*pkg.Endpoint)
+	records := make(map[string][]string)
 
 	for _, e := range endpoints {
 		record, exists := currentRecords[e.DNSName]
 
 		if !exists || exists && isResponsible(record.owner) {
-			records[e.DNSName] = append(records[e.DNSName], e)
+			records[e.DNSName] = append(records[e.DNSName], e.IP)
 		}
 	}
 
-	for dnsName, nested := range records {
-		ips := make([]string, 0, len(nested))
-		for _, svc := range nested {
-			ips = append(ips, svc.IP)
-		}
-
+	for dnsName, ips := range records {
 		change.Additions = append(change.Additions,
 			&dns.ResourceRecordSet{
 				Name:    dnsName,


### PR DESCRIPTION
This allows endpoints having the same DNS name to point to multiple IPs.

The effect is that `mate` will create multiple A records for the DNS name. This can allow clients to do some client side load-balancing or failover.

It's also a precondition for the `nodePorts`-producer that I have in the pipe.

please merge after https://github.com/zalando-incubator/mate/pull/39

/cc @mikkeloscar @ideahitme 