### PR TITLE
update documented version to v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ go get github.com/zalando-incubator/mate
 or
 
 ```
-docker run registry.opensource.zalan.do/teapot/mate:v0.3.2 --help
+docker run registry.opensource.zalan.do/teapot/mate:v0.4.0 --help
 ```
 
 # Features

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: mate
-        image: registry.opensource.zalan.do/teapot/mate:v0.3.2
+        image: registry.opensource.zalan.do/teapot/mate:v0.4.0
         args:
         - --producer=kubernetes
         - --kubernetes-format={{.Namespace}}-{{.Name}}.example.com

--- a/examples/aws/mate-deployment.yaml
+++ b/examples/aws/mate-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: mate
-        image: registry.opensource.zalan.do/teapot/mate:v0.3.2
+        image: registry.opensource.zalan.do/teapot/mate:v0.4.0
         args:
         - --producer=kubernetes
         - --kubernetes-format={{.Namespace}}-{{.Name}}.example.com


### PR DESCRIPTION
I'm going to tag the latest release with `v0.4.0` because of the support of multiple IPs for the Google consumer. I'll tag the merge commit once merged, if no objections.

/cc @ideahitme 