### PR TITLE
Install the required ca-certificates package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM alpine:latest
 MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
 
+# install ca-certificates
+RUN apk --update --no-cache add ca-certificates
+
 # add binary
 ADD build/linux/mate /
 


### PR DESCRIPTION
Not doing this makes builds without the "zalando magic" not actually work, because the AWS SDK won't be able to talk to its endpoints.

The error message "x509: failed to load system roots and no roots provided" is logged on the console in this case.