### PR TITLE
Fix getZoneIDForEndpoint to properly calculate the longest match

### DIFF
--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -213,13 +213,15 @@ func (a *awsConsumer) Process(endpoint *pkg.Endpoint) error {
 //i.e. if the record has dns name "test.sub.example.com" and route53 has two hosted zones "example.com" and "sub.example.com"
 //"sub.example.com" will be returned
 func getZoneIDForEndpoint(hostedZonesMap map[string]string, record *route53.ResourceRecordSet) string {
-	var match string
+	var matchName string
+	var matchID string
 	for zoneName, zoneID := range hostedZonesMap {
-		if strings.HasSuffix(aws.StringValue(record.Name), zoneName) && len(zoneName) > len(match) { //get the longest match for the dns name
-			match = zoneID
+		if strings.HasSuffix(aws.StringValue(record.Name), zoneName) && len(zoneName) > len(matchName) { //get the longest match for the dns name
+			matchName = zoneName
+			matchID = zoneID
 		}
 	}
-	return match
+	return matchID
 }
 
 //getGroupID returns the idenitifier for AWS records as stored in TXT records

--- a/consumers/aws_test.go
+++ b/consumers/aws_test.go
@@ -63,9 +63,11 @@ func TestGetAssignedTXTRecordObject(t *testing.T) {
 
 func TestGetZoneIDForEndpoint(t *testing.T) {
 	hostedZonesMap := map[string]string{
-		"example.com":  "example.com",
-		"test.com":     "test.com",
-		"sub.test.com": "sub.test.com",
+		"example.com":                    "id1",
+		"test.com":                       "id2",
+		"sub.test.com":                   "id3",
+		"long-sub1.internal.example.com": "id4",
+		"long-sub2.internal.example.com": "id5",
 	}
 	record1 := &route53.ResourceRecordSet{
 		Name: aws.String("name.example.com"),
@@ -76,14 +78,26 @@ func TestGetZoneIDForEndpoint(t *testing.T) {
 	record3 := &route53.ResourceRecordSet{
 		Name: aws.String("name.sub.test.com"),
 	}
-	if getZoneIDForEndpoint(hostedZonesMap, record1) != "example.com" {
+	record4 := &route53.ResourceRecordSet{
+		Name: aws.String("name.long-sub1.internal.example.com"),
+	}
+	record5 := &route53.ResourceRecordSet{
+		Name: aws.String("name.long-sub2.internal.example.com"),
+	}
+	if getZoneIDForEndpoint(hostedZonesMap, record1) != "id1" {
 		t.Errorf("Incorrect zone id for %v", record1)
 	}
-	if getZoneIDForEndpoint(hostedZonesMap, record2) != "test.com" {
+	if getZoneIDForEndpoint(hostedZonesMap, record2) != "id2" {
 		t.Errorf("Incorrect zone id for %v", record2)
 	}
-	if getZoneIDForEndpoint(hostedZonesMap, record3) != "sub.test.com" {
+	if getZoneIDForEndpoint(hostedZonesMap, record3) != "id3" {
 		t.Errorf("Incorrect zone id for %v", record3)
+	}
+	if getZoneIDForEndpoint(hostedZonesMap, record4) != "id4" {
+		t.Errorf("Incorrect zone id for %v", record4)
+	}
+	if getZoneIDForEndpoint(hostedZonesMap, record5) != "id5" {
+		t.Errorf("Incorrect zone id for %v", record5)
 	}
 }
 


### PR DESCRIPTION
The function was trying to find the longest match, but then confused the matching zoneID with the matching
zoneName. As zoneIDs are all of the same length it would pick the last zone that had a name longer than this
standard length (or the first zone, if there was never any long zone).