### PR TITLE
refactoring mate config

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,12 +30,12 @@ type mateConfig struct {
 	googleRecordGroupID string
 }
 
-func NewConfig(version string) *mateConfig {
+func newConfig(version string) *mateConfig {
 	kingpin.Version(version)
 	return &mateConfig{}
 }
 
-func (cfg *mateConfig) ParseFlags() {
+func (cfg *mateConfig) parseFlags() {
 	kingpin.Flag("producer", "The endpoints producer to use.").Required().StringVar(&cfg.producer)
 	kingpin.Flag("consumer", "The endpoints consumer to use.").Required().StringVar(&cfg.consumer)
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&cfg.debug)
@@ -61,6 +61,6 @@ func (cfg *mateConfig) ParseFlags() {
 	kingpin.Parse()
 }
 
-func (cfg *mateConfig) Validate() error {
+func (cfg *mateConfig) validate() error {
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -1,7 +1,10 @@
-package config
+package main
 
-import kingpin "gopkg.in/alecthomas/kingpin.v2"
-import "net/url"
+import (
+	"net/url"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
 
 type MateConfig struct {
 	Producer string
@@ -27,7 +30,7 @@ type MateConfig struct {
 	GoogleRecordGroupID string
 }
 
-func New(version string) *MateConfig {
+func NewConfig(version string) *MateConfig {
 	kingpin.Version(version)
 	return &MateConfig{}
 }

--- a/config.go
+++ b/config.go
@@ -6,61 +6,61 @@ import (
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
-type MateConfig struct {
-	Producer string
-	Consumer string
-	Debug    bool
-	SyncOnly bool
+type mateConfig struct {
+	producer string
+	consumer string
+	debug    bool
+	syncOnly bool
 
-	FakeDNSName       string
-	FakeMode          string
-	FakeTargetDomain  string
-	FakeFixedDNSName  string
-	FakeFixedIP       string
-	FakeFixedHostname string
+	fakeDNSName       string
+	fakeMode          string
+	fakeTargetDomain  string
+	fakeFixedDNSName  string
+	fakeFixedIP       string
+	fakeFixedHostname string
 
-	KubeServer     *url.URL
-	KubeFormat     string
-	TrackNodePorts bool
+	kubernetesServer         *url.URL
+	kubernetesFormat         string
+	kubernetesTrackNodePorts bool
 
-	AWSRecordGroupID string
+	awsRecordGroupID string
 
-	GoogleProject       string
-	GoogleZone          string
-	GoogleRecordGroupID string
+	googleProject       string
+	googleZone          string
+	googleRecordGroupID string
 }
 
-func NewConfig(version string) *MateConfig {
+func NewConfig(version string) *mateConfig {
 	kingpin.Version(version)
-	return &MateConfig{}
+	return &mateConfig{}
 }
 
-func (cfg *MateConfig) ParseFlags() {
-	kingpin.Flag("producer", "The endpoints producer to use.").Required().StringVar(&cfg.Producer)
-	kingpin.Flag("consumer", "The endpoints consumer to use.").Required().StringVar(&cfg.Consumer)
-	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&cfg.Debug)
-	kingpin.Flag("sync-only", "Disable event watcher").BoolVar(&cfg.SyncOnly)
+func (cfg *mateConfig) ParseFlags() {
+	kingpin.Flag("producer", "The endpoints producer to use.").Required().StringVar(&cfg.producer)
+	kingpin.Flag("consumer", "The endpoints consumer to use.").Required().StringVar(&cfg.consumer)
+	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&cfg.debug)
+	kingpin.Flag("sync-only", "Disable event watcher").BoolVar(&cfg.syncOnly)
 
-	kingpin.Flag("fake-dnsname", "The fake DNS name to use.").StringVar(&cfg.FakeDNSName)
-	kingpin.Flag("fake-mode", "The mode to run in.").StringVar(&cfg.FakeMode)
-	kingpin.Flag("fake-target-domain", "The target domain for hostname mode.").StringVar(&cfg.FakeTargetDomain)
-	kingpin.Flag("fake-fixed-dnsname", "The full fake DNS name to use.").StringVar(&cfg.FakeFixedDNSName)
-	kingpin.Flag("fake-fixed-ip", "The full fake IP to use.").StringVar(&cfg.FakeFixedIP)
-	kingpin.Flag("fake-fixed-hostname", "The full fake host name to use.").StringVar(&cfg.FakeFixedHostname)
+	kingpin.Flag("fake-dnsname", "The fake DNS name to use.").StringVar(&cfg.fakeDNSName)
+	kingpin.Flag("fake-mode", "The mode to run in.").StringVar(&cfg.fakeMode)
+	kingpin.Flag("fake-target-domain", "The target domain for hostname mode.").StringVar(&cfg.fakeTargetDomain)
+	kingpin.Flag("fake-fixed-dnsname", "The full fake DNS name to use.").StringVar(&cfg.fakeFixedDNSName)
+	kingpin.Flag("fake-fixed-ip", "The full fake IP to use.").StringVar(&cfg.fakeFixedIP)
+	kingpin.Flag("fake-fixed-hostname", "The full fake host name to use.").StringVar(&cfg.fakeFixedHostname)
 
-	kingpin.Flag("kubernetes-server", "The address of the Kubernetes API server.").URLVar(&cfg.KubeServer)
-	kingpin.Flag("kubernetes-format", "Format of DNS entries, e.g. {{.Name}}-{{.Namespace}}.example.com").StringVar(&cfg.KubeFormat)
-	kingpin.Flag("kubernetes-track-node-ports", "When true, generates DNS entries for type=NodePort services").BoolVar(&cfg.TrackNodePorts)
+	kingpin.Flag("kubernetes-server", "The address of the Kubernetes API server.").URLVar(&cfg.kubernetesServer)
+	kingpin.Flag("kubernetes-format", "Format of DNS entries, e.g. {{.Name}}-{{.Namespace}}.example.com").StringVar(&cfg.kubernetesFormat)
+	kingpin.Flag("kubernetes-track-node-ports", "When true, generates DNS entries for type=NodePort services").BoolVar(&cfg.kubernetesTrackNodePorts)
 
-	kingpin.Flag("aws-record-group-id", "Identifier to filter mate created records ").StringVar(&cfg.AWSRecordGroupID)
+	kingpin.Flag("aws-record-group-id", "Identifier to filter mate created records ").StringVar(&cfg.awsRecordGroupID)
 
-	kingpin.Flag("google-project", "Project ID that manages the zone").StringVar(&cfg.GoogleProject)
-	kingpin.Flag("google-zone", "Name of the zone to manage.").StringVar(&cfg.GoogleZone)
-	kingpin.Flag("google-record-group-id", "Name of the zone to manage.").StringVar(&cfg.GoogleRecordGroupID)
+	kingpin.Flag("google-project", "Project ID that manages the zone").StringVar(&cfg.googleProject)
+	kingpin.Flag("google-zone", "Name of the zone to manage.").StringVar(&cfg.googleZone)
+	kingpin.Flag("google-record-group-id", "Name of the zone to manage.").StringVar(&cfg.googleRecordGroupID)
 
 	kingpin.Parse()
 }
 
-func (cfg *MateConfig) Validate() error {
+func (cfg *mateConfig) Validate() error {
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,10 @@ type MateConfig struct {
 	Debug    bool
 	SyncOnly bool
 
-	FakeProducerConfig
-	KubernetesConfig
+	*FakeProducerConfig
+	*KubernetesConfig
+	*AWSConfig
+	*GoogleConfig
 }
 
 type FakeProducerConfig struct {
@@ -35,6 +37,16 @@ type KubernetesConfig struct {
 	KubeServer     *url.URL
 	KubeFormat     string
 	TrackNodePorts bool
+}
+
+type AWSConfig struct {
+	AWSRecordGroupID string
+}
+
+type GoogleConfig struct {
+	GoogleProject       string
+	GoogleZone          string
+	GoogleRecordGroupID string
 }
 
 func New(version string) *MateConfig {
@@ -58,6 +70,12 @@ func (cfg *MateConfig) ParseFlags() {
 	kingpin.Flag("kubernetes-server", "The address of the Kubernetes API server.").URLVar(&cfg.KubeServer)
 	kingpin.Flag("kubernetes-format", "Format of DNS entries, e.g. {{.Name}}-{{.Namespace}}.example.com").StringVar(&cfg.KubeFormat)
 	kingpin.Flag("kubernetes-track-node-ports", "When true, generates DNS entries for type=NodePort services").BoolVar(&cfg.TrackNodePorts)
+
+	kingpin.Flag("aws-record-group-id", "Identifier to filter mate created records ").StringVar(&cfg.AWSRecordGroupID)
+
+	kingpin.Flag("google-project", "Project ID that manages the zone").StringVar(&cfg.GoogleProject)
+	kingpin.Flag("google-zone", "Name of the zone to manage.").StringVar(&cfg.GoogleZone)
+	kingpin.Flag("google-record-group-id", "Name of the zone to manage.").StringVar(&cfg.GoogleRecordGroupID)
 
 	kingpin.Parse()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,47 +3,25 @@ package config
 import kingpin "gopkg.in/alecthomas/kingpin.v2"
 import "net/url"
 
-const (
-
-	// fake producer default config
-	fakeDefaultDomain = "example.org."
-	fakeIPMode        = "ip"
-	fakeHostnameMode  = "hostname"
-	fakeFixedMode     = "fixed"
-)
-
 type MateConfig struct {
 	Producer string
 	Consumer string
 	Debug    bool
 	SyncOnly bool
 
-	*FakeProducerConfig
-	*KubernetesConfig
-	*AWSConfig
-	*GoogleConfig
-}
-
-type FakeProducerConfig struct {
 	FakeDNSName       string
 	FakeMode          string
 	FakeTargetDomain  string
 	FakeFixedDNSName  string
 	FakeFixedIP       string
 	FakeFixedHostname string
-}
 
-type KubernetesConfig struct {
 	KubeServer     *url.URL
 	KubeFormat     string
 	TrackNodePorts bool
-}
 
-type AWSConfig struct {
 	AWSRecordGroupID string
-}
 
-type GoogleConfig struct {
 	GoogleProject       string
 	GoogleZone          string
 	GoogleRecordGroupID string
@@ -60,9 +38,9 @@ func (cfg *MateConfig) ParseFlags() {
 	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&cfg.Debug)
 	kingpin.Flag("sync-only", "Disable event watcher").BoolVar(&cfg.SyncOnly)
 
-	kingpin.Flag("fake-dnsname", "The fake DNS name to use.").Default(fakeDefaultDomain).StringVar(&cfg.FakeDNSName)
-	kingpin.Flag("fake-mode", "The mode to run in.").Default(fakeIPMode).StringVar(&cfg.FakeMode)
-	kingpin.Flag("fake-target-domain", "The target domain for hostname mode.").Default(fakeDefaultDomain).StringVar(&cfg.FakeTargetDomain)
+	kingpin.Flag("fake-dnsname", "The fake DNS name to use.").StringVar(&cfg.FakeDNSName)
+	kingpin.Flag("fake-mode", "The mode to run in.").StringVar(&cfg.FakeMode)
+	kingpin.Flag("fake-target-domain", "The target domain for hostname mode.").StringVar(&cfg.FakeTargetDomain)
 	kingpin.Flag("fake-fixed-dnsname", "The full fake DNS name to use.").StringVar(&cfg.FakeFixedDNSName)
 	kingpin.Flag("fake-fixed-ip", "The full fake IP to use.").StringVar(&cfg.FakeFixedIP)
 	kingpin.Flag("fake-fixed-hostname", "The full fake host name to use.").StringVar(&cfg.FakeFixedHostname)

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,67 @@
+package config
+
+import kingpin "gopkg.in/alecthomas/kingpin.v2"
+import "net/url"
+
+const (
+
+	// fake producer default config
+	fakeDefaultDomain = "example.org."
+	fakeIPMode        = "ip"
+	fakeHostnameMode  = "hostname"
+	fakeFixedMode     = "fixed"
+)
+
+type MateConfig struct {
+	Producer string
+	Consumer string
+	Debug    bool
+	SyncOnly bool
+
+	FakeProducerConfig
+	KubernetesConfig
+}
+
+type FakeProducerConfig struct {
+	FakeDNSName       string
+	FakeMode          string
+	FakeTargetDomain  string
+	FakeFixedDNSName  string
+	FakeFixedIP       string
+	FakeFixedHostname string
+}
+
+type KubernetesConfig struct {
+	KubeServer     *url.URL
+	KubeFormat     string
+	TrackNodePorts bool
+}
+
+func New(version string) *MateConfig {
+	kingpin.Version(version)
+	return &MateConfig{}
+}
+
+func (cfg *MateConfig) ParseFlags() {
+	kingpin.Flag("producer", "The endpoints producer to use.").Required().StringVar(&cfg.Producer)
+	kingpin.Flag("consumer", "The endpoints consumer to use.").Required().StringVar(&cfg.Consumer)
+	kingpin.Flag("debug", "Enable debug logging.").BoolVar(&cfg.Debug)
+	kingpin.Flag("sync-only", "Disable event watcher").BoolVar(&cfg.SyncOnly)
+
+	kingpin.Flag("fake-dnsname", "The fake DNS name to use.").Default(fakeDefaultDomain).StringVar(&cfg.FakeDNSName)
+	kingpin.Flag("fake-mode", "The mode to run in.").Default(fakeIPMode).StringVar(&cfg.FakeMode)
+	kingpin.Flag("fake-target-domain", "The target domain for hostname mode.").Default(fakeDefaultDomain).StringVar(&cfg.FakeTargetDomain)
+	kingpin.Flag("fake-fixed-dnsname", "The full fake DNS name to use.").StringVar(&cfg.FakeFixedDNSName)
+	kingpin.Flag("fake-fixed-ip", "The full fake IP to use.").StringVar(&cfg.FakeFixedIP)
+	kingpin.Flag("fake-fixed-hostname", "The full fake host name to use.").StringVar(&cfg.FakeFixedHostname)
+
+	kingpin.Flag("kubernetes-server", "The address of the Kubernetes API server.").URLVar(&cfg.KubeServer)
+	kingpin.Flag("kubernetes-format", "Format of DNS entries, e.g. {{.Name}}-{{.Namespace}}.example.com").StringVar(&cfg.KubeFormat)
+	kingpin.Flag("kubernetes-track-node-ports", "When true, generates DNS entries for type=NodePort services").BoolVar(&cfg.TrackNodePorts)
+
+	kingpin.Parse()
+}
+
+func (cfg *MateConfig) Validate() error {
+	return nil
+}

--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -11,16 +11,16 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 	awsclient "github.com/zalando-incubator/mate/pkg/aws"
 )
 
+// AWSClient interface
 type AWSClient interface {
 	ListRecordSets(zoneID string) ([]*route53.ResourceRecordSet, error)
 	ChangeRecordSets(upsert, del, create []*route53.ResourceRecordSet, zoneID string) error
-	GetCanonicalZoneIDs(lbDNS []string) (map[string]string, error)
-	GetHostedZones() (map[string]string, error)
+	GetCanonicalZoneIDs(lbDNS []string) (map[string]string, error) //get hosted zone ids for the LBs
+	GetHostedZones() (map[string]string, error)                    //get all route53 hosted zones for the account
 }
 
 type awsConsumer struct {
@@ -35,11 +35,11 @@ const (
 
 // NewAWSConsumer reates a Consumer instance to sync and process DNS
 // entries in AWS Route53.
-func NewAWSConsumer(cfg *config.AWSConfig) (Consumer, error) {
-	if cfg.AWSRecordGroupID == "" {
+func NewAWSConsumer(awsRecordGroupID string) (Consumer, error) {
+	if awsRecordGroupID == "" {
 		return nil, errors.New("please provide --aws-record-group-id")
 	}
-	return withClient(awsclient.New(awsclient.Options{}), cfg.AWSRecordGroupID), nil
+	return withClient(awsclient.New(awsclient.Options{}), awsRecordGroupID), nil
 }
 
 func withClient(c AWSClient, groupID string) *awsConsumer {

--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-
 	"strings"
 
 	"sync"
@@ -13,6 +11,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 	awsclient "github.com/zalando-incubator/mate/pkg/aws"
 )
@@ -34,17 +33,13 @@ const (
 	defaultTxtTTL        = int64(300)
 )
 
-func init() {
-	kingpin.Flag("aws-record-group-id", "Identifier to filter the mate records ").StringVar(&params.awsGroupID)
-}
-
 // NewAWSConsumer reates a Consumer instance to sync and process DNS
 // entries in AWS Route53.
-func NewAWSConsumer() (Consumer, error) {
-	if params.awsGroupID == "" {
+func NewAWSConsumer(cfg *config.AWSConfig) (Consumer, error) {
+	if cfg.AWSRecordGroupID == "" {
 		return nil, errors.New("please provide --aws-record-group-id")
 	}
-	return withClient(awsclient.New(awsclient.Options{}), params.awsGroupID), nil
+	return withClient(awsclient.New(awsclient.Options{}), cfg.AWSRecordGroupID), nil
 }
 
 func withClient(c AWSClient, groupID string) *awsConsumer {

--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -33,9 +33,9 @@ const (
 	defaultTxtTTL        = int64(300)
 )
 
-// NewAWSConsumer reates a Consumer instance to sync and process DNS
+// NewAWSRoute53Consumer reates a Consumer instance to sync and process DNS
 // entries in AWS Route53.
-func NewAWSConsumer(awsRecordGroupID string) (Consumer, error) {
+func NewAWSRoute53Consumer(awsRecordGroupID string) (Consumer, error) {
 	if awsRecordGroupID == "" {
 		return nil, errors.New("please provide --aws-record-group-id")
 	}

--- a/consumers/consumers.go
+++ b/consumers/consumers.go
@@ -8,33 +8,23 @@ import (
 	"github.com/zalando-incubator/mate/pkg"
 )
 
-// var params struct {
-// 	domain        string
-// 	project       string
-// 	zone          string
-// 	recordGroupID string
-// 	awsAccountID  string
-// 	awsRole       string
-// 	awsHostedZone string
-// 	awsGroupID    string
-// }
-
+// Consumer interface
 type Consumer interface {
 	Sync([]*pkg.Endpoint) error
 	Consume(<-chan *pkg.Endpoint, chan<- error, <-chan struct{}, *sync.WaitGroup)
 	Process(*pkg.Endpoint) error
 }
 
-// Returns a Consumer implementation.
-func New(name string, cfg *config.MateConfig) (Consumer, error) {
-	switch name {
+// New returns a Consumer implementation.
+func New(cfg *config.MateConfig) (Consumer, error) {
+	switch cfg.Consumer {
 	case "google":
-		return NewGoogleDNS(cfg.GoogleConfig)
+		return NewGoogleDNS(cfg.GoogleZone, cfg.GoogleProject, cfg.GoogleRecordGroupID)
 	case "aws":
-		return NewAWSConsumer(cfg.AWSConfig)
+		return NewAWSConsumer(cfg.AWSRecordGroupID)
 	case "stdout":
 		return NewStdout()
 	default:
-		return nil, fmt.Errorf("Unknown consumer '%s'.", name)
+		return nil, fmt.Errorf("Unknown consumer '%s'.", cfg.Consumer)
 	}
 }

--- a/consumers/consumers.go
+++ b/consumers/consumers.go
@@ -4,19 +4,20 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 )
 
-var params struct {
-	domain        string
-	project       string
-	zone          string
-	recordGroupID string
-	awsAccountID  string
-	awsRole       string
-	awsHostedZone string
-	awsGroupID    string
-}
+// var params struct {
+// 	domain        string
+// 	project       string
+// 	zone          string
+// 	recordGroupID string
+// 	awsAccountID  string
+// 	awsRole       string
+// 	awsHostedZone string
+// 	awsGroupID    string
+// }
 
 type Consumer interface {
 	Sync([]*pkg.Endpoint) error
@@ -25,23 +26,15 @@ type Consumer interface {
 }
 
 // Returns a Consumer implementation.
-func New(name string) (Consumer, error) {
-	var create func() (Consumer, error)
+func New(name string, cfg *config.MateConfig) (Consumer, error) {
 	switch name {
 	case "google":
-		create = NewGoogleDNS
+		return NewGoogleDNS(cfg.GoogleConfig)
 	case "aws":
-		create = NewAWSConsumer
+		return NewAWSConsumer(cfg.AWSConfig)
 	case "stdout":
-		create = NewStdout
+		return NewStdout()
 	default:
 		return nil, fmt.Errorf("Unknown consumer '%s'.", name)
 	}
-
-	c, err := create()
-	if err != nil {
-		return nil, fmt.Errorf("error creating consumer '%s': %v", name, err)
-	}
-
-	return c, nil
 }

--- a/consumers/consumers.go
+++ b/consumers/consumers.go
@@ -1,10 +1,8 @@
 package consumers
 
 import (
-	"fmt"
 	"sync"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 )
 
@@ -13,18 +11,4 @@ type Consumer interface {
 	Sync([]*pkg.Endpoint) error
 	Consume(<-chan *pkg.Endpoint, chan<- error, <-chan struct{}, *sync.WaitGroup)
 	Process(*pkg.Endpoint) error
-}
-
-// New returns a Consumer implementation.
-func New(cfg *config.MateConfig) (Consumer, error) {
-	switch cfg.Consumer {
-	case "google":
-		return NewGoogleDNS(cfg.GoogleZone, cfg.GoogleProject, cfg.GoogleRecordGroupID)
-	case "aws":
-		return NewAWSConsumer(cfg.AWSRecordGroupID)
-	case "stdout":
-		return NewStdout()
-	default:
-		return nil, fmt.Errorf("Unknown consumer '%s'.", cfg.Consumer)
-	}
 }

--- a/consumers/google.go
+++ b/consumers/google.go
@@ -9,7 +9,6 @@ import (
 	"github.com/zalando-incubator/mate/pkg"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/zalando-incubator/mate/config"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
@@ -33,16 +32,17 @@ type ownedRecord struct {
 	record *dns.ResourceRecordSet
 }
 
-func NewGoogleDNS(cfg *config.GoogleConfig) (Consumer, error) {
-	if cfg.GoogleZone == "" {
+// NewGoogleDNS creates
+func NewGoogleDNS(googleZone, googleProject, googleRecordGroupID string) (Consumer, error) {
+	if googleZone == "" {
 		return nil, errors.New("Please provide --google-zone")
 	}
 
-	if cfg.GoogleProject == "" {
+	if googleProject == "" {
 		return nil, errors.New("Please provide --google-project")
 	}
 
-	if cfg.GoogleRecordGroupID == "" {
+	if googleRecordGroupID == "" {
 		return nil, errors.New("Please provide --google-record-group-id")
 	}
 
@@ -61,14 +61,14 @@ func NewGoogleDNS(cfg *config.GoogleConfig) (Consumer, error) {
 		return nil, fmt.Errorf("Error creating DNS service: %v", err)
 	}
 
-	labels := []string{heritageLabel, labelPrefix + cfg.GoogleRecordGroupID}
+	labels := []string{heritageLabel, labelPrefix + googleRecordGroupID}
 
 	return &googleDNSConsumer{
 		client:  client,
 		labels:  labels,
-		groupID: cfg.GoogleRecordGroupID,
-		project: cfg.GoogleProject,
-		zone:    cfg.GoogleZone,
+		groupID: googleRecordGroupID,
+		project: googleProject,
+		zone:    googleZone,
 	}, nil
 }
 

--- a/consumers/google.go
+++ b/consumers/google.go
@@ -32,8 +32,8 @@ type ownedRecord struct {
 	record *dns.ResourceRecordSet
 }
 
-// NewGoogleDNS creates
-func NewGoogleDNS(googleZone, googleProject, googleRecordGroupID string) (Consumer, error) {
+// NewGoogleCloudDNSConsumer creates
+func NewGoogleCloudDNSConsumer(googleZone, googleProject, googleRecordGroupID string) (Consumer, error) {
 	if googleZone == "" {
 		return nil, errors.New("Please provide --google-zone")
 	}

--- a/consumers/google.go
+++ b/consumers/google.go
@@ -9,10 +9,10 @@ import (
 	"github.com/zalando-incubator/mate/pkg"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/zalando-incubator/mate/config"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (
@@ -21,8 +21,11 @@ const (
 )
 
 type googleDNSConsumer struct {
-	client *dns.Service
-	labels []string
+	client  *dns.Service
+	labels  []string
+	groupID string
+	project string
+	zone    string
 }
 
 type ownedRecord struct {
@@ -30,23 +33,16 @@ type ownedRecord struct {
 	record *dns.ResourceRecordSet
 }
 
-func init() {
-	//	kingpin.Flag("gcloud-domain", "The DNS domain to create DNS entries under.").StringVar(params.domain)
-	kingpin.Flag("google-project", "Project ID that manages the zone").StringVar(&params.project)
-	kingpin.Flag("google-zone", "Name of the zone to manage.").StringVar(&params.zone)
-	kingpin.Flag("google-record-group-id", "Name of the zone to manage.").StringVar(&params.recordGroupID)
-}
-
-func NewGoogleDNS() (Consumer, error) {
-	if params.zone == "" {
+func NewGoogleDNS(cfg *config.GoogleConfig) (Consumer, error) {
+	if cfg.GoogleZone == "" {
 		return nil, errors.New("Please provide --google-zone")
 	}
 
-	if params.project == "" {
+	if cfg.GoogleProject == "" {
 		return nil, errors.New("Please provide --google-project")
 	}
 
-	if params.recordGroupID == "" {
+	if cfg.GoogleRecordGroupID == "" {
 		return nil, errors.New("Please provide --google-record-group-id")
 	}
 
@@ -65,11 +61,14 @@ func NewGoogleDNS() (Consumer, error) {
 		return nil, fmt.Errorf("Error creating DNS service: %v", err)
 	}
 
-	labels := []string{heritageLabel, labelPrefix + params.recordGroupID}
+	labels := []string{heritageLabel, labelPrefix + cfg.GoogleRecordGroupID}
 
 	return &googleDNSConsumer{
-		client: client,
-		labels: labels,
+		client:  client,
+		labels:  labels,
+		groupID: cfg.GoogleRecordGroupID,
+		project: cfg.GoogleProject,
+		zone:    cfg.GoogleZone,
 	}, nil
 }
 
@@ -89,7 +88,7 @@ func (d *googleDNSConsumer) Sync(endpoints []*pkg.Endpoint) error {
 	for _, e := range endpoints {
 		record, exists := currentRecords[e.DNSName]
 
-		if !exists || exists && isResponsible(record.owner) {
+		if !exists || exists && d.isResponsible(record.owner) {
 			records[e.DNSName] = append(records[e.DNSName], e.IP)
 		}
 	}
@@ -112,7 +111,7 @@ func (d *googleDNSConsumer) Sync(endpoints []*pkg.Endpoint) error {
 	}
 
 	for _, r := range currentRecords {
-		if r.record != nil && isResponsible(r.owner) {
+		if r.record != nil && d.isResponsible(r.owner) {
 			change.Deletions = append(change.Deletions,
 				&dns.ResourceRecordSet{
 					Name:    r.record.Name,
@@ -132,7 +131,7 @@ func (d *googleDNSConsumer) Sync(endpoints []*pkg.Endpoint) error {
 
 	err = d.applyChange(change)
 	if err != nil {
-		return fmt.Errorf("Error applying change for %s/%s: %v", params.project, params.zone, err)
+		return fmt.Errorf("Error applying change for %s/%s: %v", d.project, d.zone, err)
 	}
 
 	return nil
@@ -185,7 +184,7 @@ func (d *googleDNSConsumer) Process(endpoint *pkg.Endpoint) error {
 
 	err := d.applyChange(change)
 	if err != nil {
-		return fmt.Errorf("Error applying change for %s/%s: %v", params.project, params.zone, err)
+		return fmt.Errorf("Error applying change for %s/%s: %v", d.project, d.zone, err)
 	}
 
 	return nil
@@ -197,22 +196,22 @@ func (d *googleDNSConsumer) applyChange(change *dns.Change) error {
 		return nil
 	}
 
-	_, err := d.client.Changes.Create(params.project, params.zone, change).Do()
+	_, err := d.client.Changes.Create(d.project, d.zone, change).Do()
 	if err != nil {
 		if strings.Contains(err.Error(), "alreadyExists") {
 			log.Warnf("Cannot update some DNS records (already exist)")
 			return nil
 		}
-		return fmt.Errorf("Unable to create change for %s/%s: %v", params.project, params.zone, err)
+		return fmt.Errorf("Unable to create change for %s/%s: %v", d.project, d.zone, err)
 	}
 
 	return nil
 }
 
 func (d *googleDNSConsumer) currentRecords() (map[string]*ownedRecord, error) {
-	resp, err := d.client.ResourceRecordSets.List(params.project, params.zone).Do()
+	resp, err := d.client.ResourceRecordSets.List(d.project, d.zone).Do()
 	if err != nil {
-		return nil, fmt.Errorf("Error getting DNS records from %s/%s: %v", params.project, params.zone, err)
+		return nil, fmt.Errorf("Error getting DNS records from %s/%s: %v", d.project, d.zone, err)
 	}
 
 	records := make(map[string]*ownedRecord)
@@ -241,18 +240,18 @@ func (d *googleDNSConsumer) currentRecords() (map[string]*ownedRecord, error) {
 
 func (d *googleDNSConsumer) printRecords(records map[string]*ownedRecord) {
 	for _, r := range records {
-		if r.record != nil && isResponsible(r.owner) {
+		if r.record != nil && d.isResponsible(r.owner) {
 			log.Debugln(" ", r.record.Name, r.record.Type, r.record.Rrdatas)
 		}
 	}
 }
 
-func isResponsible(record *dns.ResourceRecordSet) bool {
-	return record != nil && labelsMatch(record.Rrdatas)
+func (d *googleDNSConsumer) isResponsible(record *dns.ResourceRecordSet) bool {
+	return record != nil && d.labelsMatch(record.Rrdatas)
 }
 
-func labelsMatch(labels []string) bool {
+func (d *googleDNSConsumer) labelsMatch(labels []string) bool {
 	return len(labels) == 2 &&
 		strings.Trim(labels[0], `"`) == heritageLabel &&
-		strings.Trim(labels[1], `"`) == labelPrefix+params.recordGroupID
+		strings.Trim(labels[1], `"`) == labelPrefix+d.groupID
 }

--- a/consumers/stdout.go
+++ b/consumers/stdout.go
@@ -13,7 +13,7 @@ import (
 // or new file writrer better
 type stdoutConsumer struct{}
 
-func NewStdout() (Consumer, error) {
+func NewStdoutConsumer() (Consumer, error) {
 	return &stdoutConsumer{}, nil
 }
 

--- a/consumers/synced.go
+++ b/consumers/synced.go
@@ -16,8 +16,8 @@ type SyncedConsumer struct {
 // one operation at a time, and blocks
 // concurrent operations until the current one
 // finishes.
-func NewSynced(name string, cfg *config.MateConfig) (Consumer, error) {
-	consumer, err := New(name, cfg)
+func NewSynced(cfg *config.MateConfig) (Consumer, error) {
+	consumer, err := New(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/consumers/synced.go
+++ b/consumers/synced.go
@@ -15,7 +15,7 @@ type SyncedConsumer struct {
 // one operation at a time, and blocks
 // concurrent operations until the current one
 // finishes.
-func NewSynced(consumer Consumer) (Consumer, error) {
+func NewSynchronizedConsumer(consumer Consumer) (Consumer, error) {
 	return &SyncedConsumer{Consumer: consumer}, nil
 }
 

--- a/consumers/synced.go
+++ b/consumers/synced.go
@@ -6,26 +6,26 @@ import (
 	"github.com/zalando-incubator/mate/pkg"
 )
 
-type SyncedConsumer struct {
+type SynchronizedConsumer struct {
 	sync.Mutex
 	Consumer
 }
 
-// NewSynced provides a consumer that can execute only
+// NewSynchronizedConsumer provides a consumer that can execute only
 // one operation at a time, and blocks
 // concurrent operations until the current one
 // finishes.
 func NewSynchronizedConsumer(consumer Consumer) (Consumer, error) {
-	return &SyncedConsumer{Consumer: consumer}, nil
+	return &SynchronizedConsumer{Consumer: consumer}, nil
 }
 
-func (s *SyncedConsumer) Sync(endpoints []*pkg.Endpoint) error {
+func (s *SynchronizedConsumer) Sync(endpoints []*pkg.Endpoint) error {
 	s.Lock()
 	defer s.Unlock()
 	return s.Consumer.Sync(endpoints)
 }
 
-func (s *SyncedConsumer) Process(endpoint *pkg.Endpoint) error {
+func (s *SynchronizedConsumer) Process(endpoint *pkg.Endpoint) error {
 	s.Lock()
 	defer s.Unlock()
 	return s.Consumer.Process(endpoint)

--- a/consumers/synced.go
+++ b/consumers/synced.go
@@ -3,6 +3,7 @@ package consumers
 import (
 	"sync"
 
+	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 )
 
@@ -15,8 +16,8 @@ type SyncedConsumer struct {
 // one operation at a time, and blocks
 // concurrent operations until the current one
 // finishes.
-func NewSynced(name string) (Consumer, error) {
-	consumer, err := New(name)
+func NewSynced(name string, cfg *config.MateConfig) (Consumer, error) {
+	consumer, err := New(name, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/consumers/synced.go
+++ b/consumers/synced.go
@@ -3,7 +3,6 @@ package consumers
 import (
 	"sync"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 )
 
@@ -16,11 +15,7 @@ type SyncedConsumer struct {
 // one operation at a time, and blocks
 // concurrent operations until the current one
 // finishes.
-func NewSynced(cfg *config.MateConfig) (Consumer, error) {
-	consumer, err := New(cfg)
-	if err != nil {
-		return nil, err
-	}
+func NewSynced(consumer Consumer) (Consumer, error) {
 	return &SyncedConsumer{Consumer: consumer}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -13,9 +13,9 @@ import (
 var version = "Unknown"
 
 func main() {
-	cfg := NewConfig(version)
+	cfg := newConfig(version)
 
-	cfg.ParseFlags()
+	cfg.parseFlags()
 
 	if cfg.debug {
 		log.SetLevel(log.DebugLevel)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/zalando-incubator/mate/config"
@@ -20,12 +22,12 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	p, err := producers.New(cfg)
+	p, err := newProducer(cfg)
 	if err != nil {
 		log.Fatalf("Error creating producer: %v", err)
 	}
 
-	c, err := consumers.NewSynced(cfg)
+	c, err := newSyncConsumer(cfg)
 	if err != nil {
 		log.Fatalf("Error creating consumer: %v", err)
 	}
@@ -43,4 +45,48 @@ func main() {
 	}()
 
 	ctrl.Wait()
+}
+
+func newSyncConsumer(cfg *config.MateConfig) (consumers.Consumer, error) {
+	// New returns a Consumer implementation.
+	var consumer consumers.Consumer
+	var err error
+	switch cfg.Consumer {
+	case "google":
+		consumer, err = consumers.NewGoogleDNS(cfg.GoogleZone, cfg.GoogleProject, cfg.GoogleRecordGroupID)
+	case "aws":
+		consumer, err = consumers.NewAWSConsumer(cfg.AWSRecordGroupID)
+	case "stdout":
+		consumer, err = consumers.NewStdout()
+	default:
+		return nil, fmt.Errorf("Unknown consumer '%s'.", cfg.Consumer)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return consumers.NewSynced(consumer)
+}
+
+func newProducer(cfg *config.MateConfig) (producers.Producer, error) {
+	switch cfg.Producer {
+	case "kubernetes":
+		kubeConfig := &producers.KubernetesOptions{
+			Format:    cfg.KubeFormat,
+			APIServer: cfg.KubeServer,
+		}
+		return producers.NewKubernetes(kubeConfig)
+	case "fake":
+		fakeConfig := &producers.FakeProducerOptions{
+			DNSName:       cfg.FakeDNSName,
+			FixedDNSName:  cfg.FakeFixedDNSName,
+			FixedHostname: cfg.FakeFixedHostname,
+			FixedIP:       cfg.FakeFixedIP,
+			Mode:          cfg.FakeMode,
+			TargetDomain:  cfg.FakeTargetDomain,
+		}
+		return producers.NewFake(fakeConfig)
+	case "null":
+		return producers.NewNull()
+	}
+	return nil, fmt.Errorf("Unknown producer '%s'.", cfg.Producer)
 }

--- a/main.go
+++ b/main.go
@@ -20,12 +20,12 @@ func main() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	p, err := producers.New(cfg.Producer)
+	p, err := producers.New(cfg)
 	if err != nil {
 		log.Fatalf("Error creating producer: %v", err)
 	}
 
-	c, err := consumers.NewSynced(cfg.Consumer)
+	c, err := consumers.NewSynced(cfg)
 	if err != nil {
 		log.Fatalf("Error creating consumer: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/consumers"
 	"github.com/zalando-incubator/mate/controller"
 	"github.com/zalando-incubator/mate/producers"
@@ -14,7 +13,7 @@ import (
 var version = "Unknown"
 
 func main() {
-	cfg := config.New(version)
+	cfg := NewConfig(version)
 
 	cfg.ParseFlags()
 
@@ -47,7 +46,7 @@ func main() {
 	ctrl.Wait()
 }
 
-func newSyncConsumer(cfg *config.MateConfig) (consumers.Consumer, error) {
+func newSyncConsumer(cfg *MateConfig) (consumers.Consumer, error) {
 	// New returns a Consumer implementation.
 	var consumer consumers.Consumer
 	var err error
@@ -67,7 +66,7 @@ func newSyncConsumer(cfg *config.MateConfig) (consumers.Consumer, error) {
 	return consumers.NewSynced(consumer)
 }
 
-func newProducer(cfg *config.MateConfig) (producers.Producer, error) {
+func newProducer(cfg *MateConfig) (producers.Producer, error) {
 	switch cfg.Producer {
 	case "kubernetes":
 		kubeConfig := &producers.KubernetesOptions{

--- a/producers/fake.go
+++ b/producers/fake.go
@@ -9,8 +9,12 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
+)
+
+const (
+	defaultFakeDomain = "example.org."
+	defaultFakeMode   = "ip"
 )
 
 type fakeProducer struct {
@@ -22,18 +26,34 @@ type fakeProducer struct {
 	fixedHostname string
 }
 
+type FakeProducerOptions struct {
+	DNSName       string
+	Mode          string
+	TargetDomain  string
+	FixedDNSName  string
+	FixedIP       string
+	FixedHostname string
+}
+
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-func NewFake(cfg *config.MateConfig) (*fakeProducer, error) {
+func NewFake(cfg *FakeProducerOptions) (*fakeProducer, error) {
+	if cfg.DNSName == "" {
+		cfg.DNSName = defaultFakeDomain
+	}
+	if cfg.Mode == "" {
+		cfg.Mode = defaultFakeMode
+	}
+
 	return &fakeProducer{
-		mode:          cfg.FakeMode,
-		dnsName:       cfg.FakeDNSName,
-		targetDomain:  cfg.FakeTargetDomain,
-		fixedDNSName:  cfg.FakeFixedDNSName,
-		fixedIP:       cfg.FakeFixedIP,
-		fixedHostname: cfg.FakeFixedHostname,
+		mode:          cfg.Mode,
+		dnsName:       cfg.DNSName,
+		targetDomain:  cfg.TargetDomain,
+		fixedDNSName:  cfg.FixedDNSName,
+		fixedIP:       cfg.FixedIP,
+		fixedHostname: cfg.FixedHostname,
 	}, nil
 }
 

--- a/producers/fake.go
+++ b/producers/fake.go
@@ -42,7 +42,7 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-func NewFake(cfg *FakeProducerOptions) (*fakeProducer, error) {
+func NewFakeProducer(cfg *FakeProducerOptions) (*fakeProducer, error) {
 	if cfg.DNSName == "" {
 		cfg.DNSName = defaultFakeDomain
 	}
@@ -104,16 +104,16 @@ func (a *fakeProducer) generateEndpoint() (*pkg.Endpoint, error) {
 	}
 
 	switch a.mode {
-	case "ip":
+	case ipMode:
 		endpoint.IP = net.IPv4(
 			byte(randomNumber(1, 255)),
 			byte(randomNumber(1, 255)),
 			byte(randomNumber(1, 255)),
 			byte(randomNumber(1, 255)),
 		).String()
-	case "hostname":
+	case hostnameMode:
 		endpoint.Hostname = fmt.Sprintf("%s.%s", randomString(6), a.targetDomain)
-	case "fixed":
+	case fixedMode:
 		endpoint.DNSName = a.fixedDNSName
 		endpoint.IP = a.fixedIP
 		endpoint.Hostname = a.fixedHostname

--- a/producers/fake.go
+++ b/producers/fake.go
@@ -15,6 +15,9 @@ import (
 const (
 	defaultFakeDomain = "example.org."
 	defaultFakeMode   = "ip"
+	ipMode            = "ip"
+	hostnameMode      = "hostname"
+	fixedMode         = "fixed"
 )
 
 type fakeProducer struct {

--- a/producers/fake_test.go
+++ b/producers/fake_test.go
@@ -68,7 +68,7 @@ func TestNewFakeReadsConfigurationFromParams(t *testing.T) {
 	fakeParams.Mode = "mode"
 	fakeParams.TargetDomain = "targetDomain"
 
-	producer, err := NewFake(fakeParams)
+	producer, err := NewFakeProducer(fakeParams)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/producers/fake_test.go
+++ b/producers/fake_test.go
@@ -63,11 +63,12 @@ func TestFakeEndpointsResolveToHostnamesInHostnameMode(t *testing.T) {
 }
 
 func TestNewFakeReadsConfigurationFromParams(t *testing.T) {
-	fakeParams.dnsName = "dnsName"
-	fakeParams.mode = "mode"
-	fakeParams.targetDomain = "targetDomain"
+	fakeParams := &FakeProducerOptions{}
+	fakeParams.DNSName = "dnsName"
+	fakeParams.Mode = "mode"
+	fakeParams.TargetDomain = "targetDomain"
 
-	producer, err := NewFake()
+	producer, err := NewFake(fakeParams)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/producers/ingress.go
+++ b/producers/ingress.go
@@ -9,7 +9,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 	"github.com/zalando-incubator/mate/pkg/kubernetes"
 	k8s "k8s.io/client-go/kubernetes"
@@ -23,15 +22,15 @@ type kubernetesIngressProducer struct {
 	tmpl   *template.Template
 }
 
-func NewKubernetesIngress(params *config.KubernetesConfig) (*kubernetesIngressProducer, error) {
-	client, err := kubernetes.NewClient(params.KubeServer)
+func NewKubernetesIngress(cfg *KubernetesOptions) (*kubernetesIngressProducer, error) {
+	client, err := kubernetes.NewClient(cfg.APIServer)
 	if err != nil {
 		return nil, fmt.Errorf("[Ingress] Unable to setup Kubernetes API client: %v", err)
 	}
 
 	tmpl, err := template.New("endpoint").Funcs(template.FuncMap{
 		"trimPrefix": strings.TrimPrefix,
-	}).Parse(params.KubeFormat)
+	}).Parse(cfg.Format)
 	if err != nil {
 		return nil, fmt.Errorf("[Ingress] Error parsing template: %s", err)
 	}

--- a/producers/ingress.go
+++ b/producers/ingress.go
@@ -9,6 +9,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
+	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 	"github.com/zalando-incubator/mate/pkg/kubernetes"
 	k8s "k8s.io/client-go/kubernetes"
@@ -22,15 +23,15 @@ type kubernetesIngressProducer struct {
 	tmpl   *template.Template
 }
 
-func NewKubernetesIngress() (*kubernetesIngressProducer, error) {
-	client, err := kubernetes.NewClient(kubernetesParams.kubeServer)
+func NewKubernetesIngress(params *config.KubernetesConfig) (*kubernetesIngressProducer, error) {
+	client, err := kubernetes.NewClient(params.KubeServer)
 	if err != nil {
 		return nil, fmt.Errorf("[Ingress] Unable to setup Kubernetes API client: %v", err)
 	}
 
 	tmpl, err := template.New("endpoint").Funcs(template.FuncMap{
 		"trimPrefix": strings.TrimPrefix,
-	}).Parse(kubernetesParams.format)
+	}).Parse(params.KubeFormat)
 	if err != nil {
 		return nil, fmt.Errorf("[Ingress] Error parsing template: %s", err)
 	}

--- a/producers/kubernetes.go
+++ b/producers/kubernetes.go
@@ -3,11 +3,11 @@ package producers
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 )
 
@@ -21,8 +21,14 @@ type kubernetesProducer struct {
 	nodePorts Producer
 }
 
-func NewKubernetes(cfg *config.KubernetesConfig) (*kubernetesProducer, error) {
-	if cfg.KubeFormat == "" {
+type KubernetesOptions struct {
+	APIServer      *url.URL
+	Format         string
+	TrackNodePorts bool
+}
+
+func NewKubernetes(cfg *KubernetesOptions) (*kubernetesProducer, error) {
+	if cfg.Format == "" {
 		return nil, errors.New("Please provide --kubernetes-format")
 	}
 

--- a/producers/kubernetes.go
+++ b/producers/kubernetes.go
@@ -27,7 +27,7 @@ type KubernetesOptions struct {
 	TrackNodePorts bool
 }
 
-func NewKubernetes(cfg *KubernetesOptions) (*kubernetesProducer, error) {
+func NewKubernetesProducer(cfg *KubernetesOptions) (*kubernetesProducer, error) {
 	if cfg.Format == "" {
 		return nil, errors.New("Please provide --kubernetes-format")
 	}
@@ -53,7 +53,7 @@ func NewKubernetes(cfg *KubernetesOptions) (*kubernetesProducer, error) {
 	if cfg.TrackNodePorts {
 		producer.nodePorts, err = NewKubernetesNodePorts(cfg)
 	} else {
-		producer.nodePorts, err = NewNull()
+		producer.nodePorts, err = NewNullProducer()
 	}
 	if err != nil {
 		return nil, fmt.Errorf("[Kubernetes] Error creating producer: %v", err)

--- a/producers/node_ports.go
+++ b/producers/node_ports.go
@@ -12,6 +12,7 @@ import (
 	api "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/watch"
 
+	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 	"github.com/zalando-incubator/mate/pkg/kubernetes"
 	k8s "k8s.io/client-go/kubernetes"
@@ -22,15 +23,15 @@ type kubernetesNodePortsProducer struct {
 	tmpl   *template.Template
 }
 
-func NewKubernetesNodePorts() (*kubernetesNodePortsProducer, error) {
-	client, err := kubernetes.NewClient(kubernetesParams.kubeServer)
+func NewKubernetesNodePorts(params *config.KubernetesConfig) (*kubernetesNodePortsProducer, error) {
+	client, err := kubernetes.NewClient(params.KubeServer)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to setup Kubernetes API client: %v", err)
 	}
 
 	tmpl, err := template.New("endpoint").Funcs(template.FuncMap{
 		"trimPrefix": strings.TrimPrefix,
-	}).Parse(kubernetesParams.format)
+	}).Parse(params.KubeFormat)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing template: %s", err)
 	}

--- a/producers/node_ports.go
+++ b/producers/node_ports.go
@@ -12,7 +12,6 @@ import (
 	api "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/watch"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 	"github.com/zalando-incubator/mate/pkg/kubernetes"
 	k8s "k8s.io/client-go/kubernetes"
@@ -23,15 +22,15 @@ type kubernetesNodePortsProducer struct {
 	tmpl   *template.Template
 }
 
-func NewKubernetesNodePorts(params *config.KubernetesConfig) (*kubernetesNodePortsProducer, error) {
-	client, err := kubernetes.NewClient(params.KubeServer)
+func NewKubernetesNodePorts(cfg *KubernetesOptions) (*kubernetesNodePortsProducer, error) {
+	client, err := kubernetes.NewClient(cfg.APIServer)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to setup Kubernetes API client: %v", err)
 	}
 
 	tmpl, err := template.New("endpoint").Funcs(template.FuncMap{
 		"trimPrefix": strings.TrimPrefix,
-	}).Parse(params.KubeFormat)
+	}).Parse(cfg.Format)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing template: %s", err)
 	}

--- a/producers/null.go
+++ b/producers/null.go
@@ -10,7 +10,7 @@ import (
 
 type nullProducer struct{}
 
-func NewNull() (*nullProducer, error) {
+func NewNullProducer() (*nullProducer, error) {
 	return &nullProducer{}, nil
 }
 

--- a/producers/producers.go
+++ b/producers/producers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 )
 
@@ -12,14 +13,26 @@ type Producer interface {
 	Monitor(chan *pkg.Endpoint, chan error, chan struct{}, *sync.WaitGroup)
 }
 
-func New(name string) (Producer, error) {
-	switch name {
+func New(cfg *config.MateConfig) (Producer, error) {
+	switch cfg.Producer {
 	case "kubernetes":
-		return NewKubernetes(nil)
+		kubeConfig := &KubernetesOptions{
+			Format:    cfg.KubeFormat,
+			APIServer: cfg.KubeServer,
+		}
+		return NewKubernetes(kubeConfig)
 	case "fake":
-		return NewFake(nil)
+		fakeConfig := &FakeProducerOptions{
+			DNSName:       cfg.FakeDNSName,
+			FixedDNSName:  cfg.FakeFixedDNSName,
+			FixedHostname: cfg.FakeFixedHostname,
+			FixedIP:       cfg.FakeFixedIP,
+			Mode:          cfg.FakeMode,
+			TargetDomain:  cfg.FakeTargetDomain,
+		}
+		return NewFake(fakeConfig)
 	case "null":
 		return NewNull()
 	}
-	return nil, fmt.Errorf("Unknown producer '%s'.", name)
+	return nil, fmt.Errorf("Unknown producer '%s'.", cfg.Producer)
 }

--- a/producers/producers.go
+++ b/producers/producers.go
@@ -15,9 +15,9 @@ type Producer interface {
 func New(name string) (Producer, error) {
 	switch name {
 	case "kubernetes":
-		return NewKubernetes()
+		return NewKubernetes(nil)
 	case "fake":
-		return NewFake()
+		return NewFake(nil)
 	case "null":
 		return NewNull()
 	}

--- a/producers/producers.go
+++ b/producers/producers.go
@@ -1,38 +1,12 @@
 package producers
 
 import (
-	"fmt"
 	"sync"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 )
 
 type Producer interface {
 	Endpoints() ([]*pkg.Endpoint, error)
 	Monitor(chan *pkg.Endpoint, chan error, chan struct{}, *sync.WaitGroup)
-}
-
-func New(cfg *config.MateConfig) (Producer, error) {
-	switch cfg.Producer {
-	case "kubernetes":
-		kubeConfig := &KubernetesOptions{
-			Format:    cfg.KubeFormat,
-			APIServer: cfg.KubeServer,
-		}
-		return NewKubernetes(kubeConfig)
-	case "fake":
-		fakeConfig := &FakeProducerOptions{
-			DNSName:       cfg.FakeDNSName,
-			FixedDNSName:  cfg.FakeFixedDNSName,
-			FixedHostname: cfg.FakeFixedHostname,
-			FixedIP:       cfg.FakeFixedIP,
-			Mode:          cfg.FakeMode,
-			TargetDomain:  cfg.FakeTargetDomain,
-		}
-		return NewFake(fakeConfig)
-	case "null":
-		return NewNull()
-	}
-	return nil, fmt.Errorf("Unknown producer '%s'.", cfg.Producer)
 }

--- a/producers/service.go
+++ b/producers/service.go
@@ -12,7 +12,6 @@ import (
 	api "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/watch"
 
-	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 	"github.com/zalando-incubator/mate/pkg/kubernetes"
 	k8s "k8s.io/client-go/kubernetes"
@@ -23,15 +22,15 @@ type kubernetesServiceProducer struct {
 	tmpl   *template.Template
 }
 
-func NewKubernetesService(params *config.KubernetesConfig) (*kubernetesServiceProducer, error) {
-	client, err := kubernetes.NewClient(params.KubeServer)
+func NewKubernetesService(cfg *KubernetesOptions) (*kubernetesServiceProducer, error) {
+	client, err := kubernetes.NewClient(cfg.APIServer)
 	if err != nil {
 		return nil, fmt.Errorf("[Service] Unable to setup Kubernetes API client: %v", err)
 	}
 
 	tmpl, err := template.New("endpoint").Funcs(template.FuncMap{
 		"trimPrefix": strings.TrimPrefix,
-	}).Parse(params.KubeFormat)
+	}).Parse(cfg.Format)
 	if err != nil {
 		return nil, fmt.Errorf("[Service] Error parsing template: %s", err)
 	}

--- a/producers/service.go
+++ b/producers/service.go
@@ -12,6 +12,7 @@ import (
 	api "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/watch"
 
+	"github.com/zalando-incubator/mate/config"
 	"github.com/zalando-incubator/mate/pkg"
 	"github.com/zalando-incubator/mate/pkg/kubernetes"
 	k8s "k8s.io/client-go/kubernetes"
@@ -22,15 +23,15 @@ type kubernetesServiceProducer struct {
 	tmpl   *template.Template
 }
 
-func NewKubernetesService() (*kubernetesServiceProducer, error) {
-	client, err := kubernetes.NewClient(kubernetesParams.kubeServer)
+func NewKubernetesService(params *config.KubernetesConfig) (*kubernetesServiceProducer, error) {
+	client, err := kubernetes.NewClient(params.KubeServer)
 	if err != nil {
 		return nil, fmt.Errorf("[Service] Unable to setup Kubernetes API client: %v", err)
 	}
 
 	tmpl, err := template.New("endpoint").Funcs(template.FuncMap{
 		"trimPrefix": strings.TrimPrefix,
-	}).Parse(kubernetesParams.format)
+	}).Parse(params.KubeFormat)
 	if err != nil {
 		return nil, fmt.Errorf("[Service] Error parsing template: %s", err)
 	}


### PR DESCRIPTION
1. Create config.go to store all mate configurations 
2. Remove flags initialisation from all internal packages (this is generally a bad practice to do so) 
3. Make internal packages more independent and actually "invocable" 