### PR TITLE
make mate play well with other ext dns controllers

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type mateConfig struct {
 	kubernetesServer         *url.URL
 	kubernetesFormat         string
 	kubernetesTrackNodePorts bool
+	kubernetesFilter         map[string]string
 
 	awsRecordGroupID string
 
@@ -32,7 +33,7 @@ type mateConfig struct {
 
 func newConfig(version string) *mateConfig {
 	kingpin.Version(version)
-	return &mateConfig{}
+	return &mateConfig{kubernetesFilter: map[string]string{}}
 }
 
 func (cfg *mateConfig) parseFlags() {
@@ -51,6 +52,7 @@ func (cfg *mateConfig) parseFlags() {
 	kingpin.Flag("kubernetes-server", "The address of the Kubernetes API server.").URLVar(&cfg.kubernetesServer)
 	kingpin.Flag("kubernetes-format", "Format of DNS entries, e.g. {{.Name}}-{{.Namespace}}.example.com").StringVar(&cfg.kubernetesFormat)
 	kingpin.Flag("kubernetes-track-node-ports", "When true, generates DNS entries for type=NodePort services").BoolVar(&cfg.kubernetesTrackNodePorts)
+	kingpin.Flag("kubernetes-filter", "A set of annotations that must match in order to process the object.").StringMapVar(&cfg.kubernetesFilter)
 
 	kingpin.Flag("aws-record-group-id", "Identifier to filter mate created records ").StringVar(&cfg.awsRecordGroupID)
 

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func newProducer(cfg *mateConfig) (producers.Producer, error) {
 			Format:         cfg.kubernetesFormat,
 			APIServer:      cfg.kubernetesServer,
 			TrackNodePorts: cfg.kubernetesTrackNodePorts,
+			Filter:         cfg.kubernetesFilter,
 		}
 		return producers.NewKubernetesProducer(kubeConfig)
 	case "fake":

--- a/producers/ingress_test.go
+++ b/producers/ingress_test.go
@@ -1,0 +1,42 @@
+package producers
+
+import (
+	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
+	extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func TestValidateIngress(t *testing.T) {
+	loadBalancer := v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{v1.LoadBalancerIngress{IP: "8.8.8.8"}},
+	}
+
+	emptyIngress := extensions.Ingress{}
+
+	validIngress := extensions.Ingress{
+		Status: extensions.IngressStatus{LoadBalancer: loadBalancer},
+	}
+
+	validMatchedIngress := extensions.Ingress{
+		ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"foo": "bar"}},
+		Status:     extensions.IngressStatus{LoadBalancer: loadBalancer},
+	}
+
+	for _, test := range []struct {
+		ingress extensions.Ingress
+		filter  map[string]string
+		isErr   bool
+	}{
+		{emptyIngress, map[string]string{}, false},
+		{validIngress, map[string]string{}, true},
+		{validIngress, map[string]string{"foo": "bar"}, false},
+		{validMatchedIngress, map[string]string{"foo": "bar"}, true},
+		{validMatchedIngress, map[string]string{"foo": "qux"}, false},
+	} {
+		result := validateIngress(test.ingress, test.filter)
+		if _, isErr := result.(error); isErr == test.isErr {
+			t.Errorf("validateIngress(%q, %q) => %q, want %t", test.ingress.Name, test.filter, result, test.isErr)
+		}
+	}
+}

--- a/producers/kubernetes.go
+++ b/producers/kubernetes.go
@@ -25,6 +25,7 @@ type KubernetesOptions struct {
 	APIServer      *url.URL
 	Format         string
 	TrackNodePorts bool
+	Filter         map[string]string
 }
 
 func NewKubernetesProducer(cfg *KubernetesOptions) (*kubernetesProducer, error) {

--- a/producers/service_test.go
+++ b/producers/service_test.go
@@ -1,0 +1,41 @@
+package producers
+
+import (
+	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func TestValidateService(t *testing.T) {
+	loadBalancer := v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{v1.LoadBalancerIngress{IP: "8.8.8.8"}},
+	}
+
+	emptyService := v1.Service{}
+
+	validService := v1.Service{
+		Status: v1.ServiceStatus{LoadBalancer: loadBalancer},
+	}
+
+	validMatchedService := v1.Service{
+		ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{"foo": "bar"}},
+		Status:     v1.ServiceStatus{LoadBalancer: loadBalancer},
+	}
+
+	for _, test := range []struct {
+		service v1.Service
+		filter  map[string]string
+		isErr   bool
+	}{
+		{emptyService, map[string]string{}, false},
+		{validService, map[string]string{}, true},
+		{validService, map[string]string{"foo": "bar"}, false},
+		{validMatchedService, map[string]string{"foo": "bar"}, true},
+		{validMatchedService, map[string]string{"foo": "qux"}, false},
+	} {
+		result := validateService(test.service, test.filter)
+		if _, isErr := result.(error); isErr == test.isErr {
+			t.Errorf("validateService(%q, %q) => %q, want %t", test.service.Name, test.filter, result, test.isErr)
+		}
+	}
+}


### PR DESCRIPTION
This allows to pass an annotation selector to `mate` which will instruct it to filter services and ingresses based on that. This allows for numerous possibilities to opt-in to being processed by different dns controllers and versions.

For example, calling `mate` with

```
./mate \
  --producer kubernetes \
  --kubernetes-filter external-dns.kubernetes.io/controller=mate/v1 \
  [...]
```

will allow it to play well with other dns controllers. Cluster users can annotate their service according to the agreed upon annotations and opt-in to have their service processed by `mate`.