### PR TITLE
Safely handle records without ResourceRecords

### DIFF
--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -265,7 +265,7 @@ func (a *awsConsumer) recordInfo(records []*route53.ResourceRecordSet) map[strin
 	groupIDMap := map[string]string{} //maps dns to group ID
 
 	for _, record := range records {
-		if (aws.StringValue(record.Type)) == "TXT" {
+		if aws.StringValue(record.Type) == "TXT" && len(record.ResourceRecords) > 0 {
 			groupIDMap[aws.StringValue(record.Name)] = aws.StringValue(record.ResourceRecords[0].Value)
 		} else {
 			if _, exist := groupIDMap[aws.StringValue(record.Name)]; !exist {

--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -269,7 +269,7 @@ func (a *awsConsumer) groupIDInfo(records []*route53.ResourceRecordSet) map[stri
 			if len(record.ResourceRecords) > 0 {
 				groupIDMap[aws.StringValue(record.Name)] = aws.StringValue(record.ResourceRecords[0].Value)
 			} else {
-				log.Errorf("Unexpected response from AWS API, got TXT record with empty resources: %s . Record is excluded from syncing", aws.StringValue(record.Name))
+				log.Errorf("Unexpected response from AWS API, got TXT record with empty resources: %s. Record is excluded from syncing", aws.StringValue(record.Name))
 				groupIDMap[aws.StringValue(record.Name)] = ""
 			}
 		} else {

--- a/consumers/aws.go
+++ b/consumers/aws.go
@@ -265,8 +265,13 @@ func (a *awsConsumer) recordInfo(records []*route53.ResourceRecordSet) map[strin
 	groupIDMap := map[string]string{} //maps dns to group ID
 
 	for _, record := range records {
-		if aws.StringValue(record.Type) == "TXT" && len(record.ResourceRecords) > 0 {
-			groupIDMap[aws.StringValue(record.Name)] = aws.StringValue(record.ResourceRecords[0].Value)
+		if aws.StringValue(record.Type) == "TXT" {
+			if len(record.ResourceRecords) > 0 {
+				groupIDMap[aws.StringValue(record.Name)] = aws.StringValue(record.ResourceRecords[0].Value)
+			} else {
+				log.Errorf("Unexpected response from AWS API, got TXT record with empty resources: %s. Record is excluded from syncing", aws.StringValue(record.Name))
+				groupIDMap[aws.StringValue(record.Name)] = ""
+			}
 		} else {
 			if _, exist := groupIDMap[aws.StringValue(record.Name)]; !exist {
 				groupIDMap[aws.StringValue(record.Name)] = ""

--- a/consumers/aws_test.go
+++ b/consumers/aws_test.go
@@ -152,12 +152,17 @@ func TestRecordInfo(t *testing.T) {
 		},
 		&route53.ResourceRecordSet{
 			Type:            aws.String("TXT"),
-			Name:            aws.String("test.example.com."),
+			Name:            aws.String("unusual-1.example.com."),
 			ResourceRecords: nil,
+		},
+		&route53.ResourceRecordSet{
+			Type:            aws.String("TXT"),
+			Name:            aws.String("unusual-2.example.com."),
+			ResourceRecords: []*route53.ResourceRecord{},
 		},
 	}
 	recordInfoMap := client.recordInfo(records)
-	if len(recordInfoMap) != 1 {
+	if len(recordInfoMap) != 3 {
 		t.Errorf("Incorrect record info for %v", records)
 	}
 	if val, exist := recordInfoMap["test.example.com."]; !exist {

--- a/consumers/aws_test.go
+++ b/consumers/aws_test.go
@@ -150,6 +150,11 @@ func TestRecordInfo(t *testing.T) {
 				},
 			},
 		},
+		&route53.ResourceRecordSet{
+			Type:            aws.String("TXT"),
+			Name:            aws.String("test.example.com."),
+			ResourceRecords: nil,
+		},
 	}
 	recordInfoMap := client.recordInfo(records)
 	if len(recordInfoMap) != 1 {


### PR DESCRIPTION
Always check the length of ResourceRecords before trying to index.

Fix #87

@snoby this should fix the issue you were seeing. I have built an image `mikkeloscar/mate:v0.6.0-1-gfbdce6b` which you can try out if you like.

You can also build your own image:

```
$ IMAGE=your_user/mate make build.push
```

Where `your_user` is your docker hub username. 

/cc @ideahitme @linki 