### PR TITLE
add small note mentioning kube-aws-ingress-controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Mate locally with the server URL set to `http://127.0.0.1:8001` and use
 
 # Ingress 
 
-In Zalando we use our in-house built ingress controller - [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller) which makes the whole setup super simple and it is production tested. Please refer to the [ingress controller readme](https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/ingress.html) for usage manual.
+In Zalando we use our in-house built ingress controller - [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller) which makes the whole setup super simple and it is production tested. Please refer to the [ingress section](https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/ingress.html) for usage manual.
 
 # Producers and Consumers
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ API server url using the flag `kubernetes-server`. For instance you can run
 Mate locally with the server URL set to `http://127.0.0.1:8001` and use
 `kubectl proxy` to forward requests to a cluster.
 
-# Ingress 
+# Ingress
 
-In Zalando we use our in-house built ingress controller - [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller) which makes the whole setup super simple and it is production tested. Please refer to the [ingress section](https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/ingress.html) for usage manual.
+In Zalando we use our in-house built ingress controller on AWS - [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller) which makes the whole setup super simple and it is production tested. Please refer to the [ingress section](https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/ingress.html) for usage manual.
 
 # Producers and Consumers
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ API server url using the flag `kubernetes-server`. For instance you can run
 Mate locally with the server URL set to `http://127.0.0.1:8001` and use
 `kubectl proxy` to forward requests to a cluster.
 
+# Ingress 
+
+In Zalando we use our in-house built ingress controller - [kube-ingress-aws-controller](https://github.com/zalando-incubator/kube-ingress-aws-controller) which makes the whole setup super simple and it is production tested. Please refer to the [ingress controller readme](https://kubernetes-on-aws.readthedocs.io/en/latest/user-guide/ingress.html) for usage manual.
+
 # Producers and Consumers
 
 Mate supports swapping out Endpoint producers (e.g. a service list from Kubernetes) and endpoint consumers (e.g. making API calls to Google to create DNS records) and both sides are pluggable. There currently exist two producer and three consumer implementations.


### PR DESCRIPTION
/cc @linki @hjacobs @mikkeloscar @Raffo 

I thought it makes sense to mention kube-ingress-aws-controller in the readme.md file. To direct Mate users in the direction of using kube-ingress-aws-controller/mate/skipper setup to have our battle-tested setup

